### PR TITLE
packaging: migrate Homebrew publishing from brews to homebrew_casks

### DIFF
--- a/.goreleaser.yaml
+++ b/.goreleaser.yaml
@@ -93,37 +93,42 @@ archives:
       - LICENSE
       - README.md
 
-# Homebrew tap — publishes Formula/pg_hardstorage.rb to the org-wide
-# tap repo on each release, so `brew install cybertec-postgresql/tap/
-# pg_hardstorage` works on macOS (Apple Silicon) and Linux
-# (amd64/arm64).  goreleaser generates the formula from the
-# pg_hardstorage archive and commits it to the tap.
+# Homebrew cask — publishes Casks/pg_hardstorage.rb to the org-wide tap
+# on each release, so `brew install cybertec-postgresql/tap/pg_hardstorage`
+# works on macOS (Apple Silicon) and Linux (amd64/arm64).  goreleaser
+# generates the cask from the pg_hardstorage archive and commits it.
+#
+# Why a cask and not a formula: goreleaser deprecated the `brews:`
+# (formula) pipe in v2.16 in favour of `homebrew_casks:` — formulas were
+# a hack for shipping pre-compiled binaries; casks are the supported way
+# now.  The install command for end users is unchanged.
 #
 # Auth: the default GITHUB_TOKEN can only write the current repo, so the
 # push to the separate tap repo uses HOMEBREW_TAP_TOKEN (a fine-grained
 # PAT scoped to contents:write on homebrew-tap), passed through in
 # .github/workflows/release.yml.
-brews:
+homebrew_casks:
   - name: pg_hardstorage
     # Only the pg_hardstorage CLI archive — without this filter goreleaser
     # would also pull in the pg_hardstorage_testkit archive (two archives
-    # per OS/arch), producing an ambiguous formula. Mirrors nfpms.ids.
+    # per OS/arch), producing an ambiguous cask. Mirrors nfpms.ids.
     ids: [pg_hardstorage]
+    binaries:
+      - pg_hardstorage
     repository:
       owner: cybertec-postgresql
       name: homebrew-tap
       token: "{{ .Env.HOMEBREW_TAP_TOKEN }}"
-    # Commit author for the formula bump in the tap repo.
+    # Commit author for the cask bump in the tap repo.
     commit_author:
       name: cybertec-postgresql
       email: office@cybertec.at
-    commit_msg_template: "pg_hardstorage: update formula to {{ .Tag }}"
+    commit_msg_template: "pg_hardstorage: update cask to {{ .Tag }}"
     homepage: "https://github.com/cybertec-postgresql/pg_hardstorage"
     description: >-
       PostgreSQL backup, done right — agent + CLI with continuous WAL
       streaming, content-addressed dedup, envelope encryption, and
       signed manifests.
-    license: "Apache-2.0"
     # No hard PostgreSQL dependency: the agent talks to PostgreSQL over
     # the replication protocol (often a *remote* DB), so forcing a local
     # server build on every install is wrong.  Surface the optional
@@ -136,10 +141,18 @@ brews:
         brew install postgresql@18   # full server
 
       Docs: https://docs.pghardstorage.org
-    test: |
-      system "#{bin}/pg_hardstorage", "version"
-    install: |
-      bin.install "pg_hardstorage"
+    hooks:
+      post:
+        # The release binaries are cosign-signed but NOT Apple-notarised,
+        # so on macOS Gatekeeper would quarantine the binary and refuse to
+        # run it ("pg_hardstorage is damaged and cannot be opened").  Strip
+        # the quarantine xattr on install.  Guarded by OS.mac? so the Linux
+        # cask path is unaffected.
+        install: |
+          if OS.mac?
+            system_command "/usr/bin/xattr",
+                           args: ["-dr", "com.apple.quarantine", "#{staged_path}/pg_hardstorage"]
+          end
 
 checksum:
   name_template: "checksums.txt"

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,15 +11,18 @@ keeps reading that version for at least 24 months after a successor lands.
 
 ## [Unreleased]
 
-### Packaging: publish a Homebrew formula on release
+### Packaging: publish a Homebrew cask on release
 
-goreleaser now generates and pushes a Homebrew formula to the org-wide
-tap (cybertec-postgresql/homebrew-tap) on each release, so
+goreleaser now generates and pushes a Homebrew cask to the org-wide tap
+(cybertec-postgresql/homebrew-tap) on each release, so
 `brew install cybertec-postgresql/tap/pg_hardstorage` works on macOS
-(Apple Silicon) and Linux (amd64/arm64). No hard PostgreSQL dependency:
+(Apple Silicon) and Linux (amd64/arm64). A cask (not a formula) is used
+because goreleaser deprecated the formula pipe in v2.16. The macOS path
+strips the Gatekeeper quarantine xattr on install, since the binaries
+are cosign-signed but not Apple-notarised. No hard PostgreSQL dependency:
 the agent talks to PostgreSQL over the replication protocol, so the
-optional psql client is surfaced as a caveat instead. The formula push
-uses a dedicated HOMEBREW_TAP_TOKEN secret.
+optional psql client is surfaced as a caveat instead. The push uses a
+dedicated HOMEBREW_TAP_TOKEN secret.
 
 ### Installer: fix and harden the curl|sh installer
 


### PR DESCRIPTION
goreleaser deprecated the `brews:` (formula) pipe in v2.16 in favour of `homebrew_casks:` — `goreleaser check` fails the formula config as "uses deprecated properties". Migrate the Homebrew publish accordingly:

- brews: -> homebrew_casks:
- install block (bin.install) -> binaries: [pg_hardstorage]
- drop the formula-only test: block
- add a postflight hook that strips the Gatekeeper quarantine xattr on macOS (OS.mac?-guarded): the release binaries are cosign-signed but not Apple-notarised, so without it macOS refuses to run the binary ("pg_hardstorage is damaged and cannot be opened")

The end-user install command is unchanged
(`brew install cybertec-postgresql/tap/pg_hardstorage`), still covering macOS arm64 and Linux amd64/arm64, still no hard PostgreSQL dependency.

Verified with `goreleaser check` (validated, no deprecation) and a full `goreleaser release --snapshot` that generated a correct Casks/pg_hardstorage.rb (per-platform url/sha256, binary, postflight, caveats). Since no tag release has populated the tap yet, no Formula cleanup / tap_migrations.json is needed.


## Summary

Migrate Homebrew publishing from the deprecated `brews:` (formula) pipe to `homebrew_casks:`. goreleaser deprecated `brews:` in v2.16, so the previous config would fail `goreleaser check`. The end-user install command is unchanged (`brew install cybertec-postgresql/tap/pg_hardstorage`); the macOS path now strips the Gatekeeper quarantine xattr since the binaries are cosign-signed but not Apple-notarised.

## Type

- [x] Bug fix
- [ ] New feature
- [ ] Refactor (no behaviour change)
- [ ] Documentation
- [ ] Test infrastructure
- [x] Packaging / release

## Tests

- [ ] `make check` passes locally (vet + race tests)
- [x] New tests added for the changed behaviour, or there's a clear reason none exist <!-- Release-config only. Verified with `goreleaser check` (validated, no deprecation) and a full `goreleaser release --snapshot --clean --skip=docker,sign,sbom,publish`, which generated a correct dist/homebrew/Casks/pg_hardstorage.rb: macOS arm64 + Linux amd64/arm64, binary stanza, OS.mac?-guarded postflight xattr, caveats, per-platform url/sha256. -->
- [ ] Integration tests pass (`make test-integration`) where touched

## Compatibility

- [x] No on-disk manifest schema changes (or: schema bumped + 24-month back-read preserved)
- [x] No CLI / API contract changes (or: documented + bumped) <!-- brew install command unchanged; this only changes how the artifact is packaged in the tap (cask vs formula). -->
- [x] No new external dependencies (or: justified in the description) <!-- Uses goreleaser's built-in homebrew_casks pipe; no new deps. Same HOMEBREW_TAP_TOKEN secret as before. -->

## Checklist

- [x] Maintainer-attribution authoring (`Author: Hans-Jürgen Schönig <hs@cybertec.at>`)
- [x] No AI-attribution lines anywhere
- [x] CHANGELOG.md updated under the unreleased section
- [x] Comments explain WHY (not WHAT) where the code isn't self-evident

Reviewer / release notes:
  - Supersedes the brews: config from #5 (not yet exercised by a release,
    so the tap is still empty — no Formula/ cleanup or tap_migrations.json
    needed).
  - First real population of the tap happens on the next v* tag (e.g.
    v1.0.1). After that, test: brew install cybertec-postgresql/tap/pg_hardstorage
  - The postflight xattr strip is a Gatekeeper workaround for un-notarised
    binaries; revisit if/when Apple notarisation is added to the release.