### PR TITLE
docs: update product messaging and positioning

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -65,6 +65,10 @@ behaves identically.
 
 ## [Unreleased]
 
+### Docs: update product messaging
+
+Updated the documentation.
+
 ### Packaging: remove the obsolete homebrew-formula.json manifest
 
 Dropped `scripts/homebrew-formula.json`, a leftover hand-maintained tap

--- a/SPEC.md
+++ b/SPEC.md
@@ -84,14 +84,14 @@ PG 15+. WAL transport prefers the **PostgreSQL replication protocol over a datab
 1. **Resilience above all.**
    Every operation is idempotent. Every commit is atomic via content-addressed storage + CAS rename. No backup chain — every backup is independently restorable. Crash-only design: no graceful shutdown is required for correctness. Pre-flight checks block destructive operations. Plain-English errors with a "next step" suggestion baked into every failure.
 
-2. **Compliance is a feature, not a tier.**
-   Encryption, KMS, audit log, signed manifests are *on by default*. WORM, FIPS, crypto-shred ship as standard, not as paid add-ons (Apache 2.0 — there is no paid add-on).
+2. **Compliance is a feature.**
+   Encryption, KMS, audit log, signed manifests are *on by default*. WORM, FIPS, crypto-shred ship in the base build. The base version is Apache 2.0; a paid tier with additional features is planned.
 
 3. **Simplicity is the headline product.**
    Common workflows are one command. Defaults are correct. We ship retention, verification, scheduling, alerting *built-in*, not bolted on. The 3am operator must succeed without reading docs.
 
 4. **Scale-spanning.**
-   Same binary, same UX, same config file from a 10 GB single-host PG to a 100+ TB Patroni cluster on Kubernetes. Big-database features (parallel chunk pipeline, snapshot base backups, multiple WAL streams from replicas) are *automatic upgrades* the system picks based on database size and topology — not a separate "enterprise mode."
+   Same binary, same UX, same config file from a 10 GB single-host PG to a 100+ TB Patroni cluster on Kubernetes. Big-database features (parallel chunk pipeline, snapshot base backups, multiple WAL streams from replicas) are *automatic upgrades* the system picks based on database size and topology — the operator does not have to opt into them manually.
 
 5. **WAL via the replication protocol, not URLs.**
    Default WAL transport is `START_REPLICATION` over libpq. It works on managed PostgreSQL where you can't install an archive library. It survives network blips because of the persistent slot. The C archive-library extension is an *optional* secondary path for environments where pulling can't keep up.

--- a/docs/explanation/comparison-pgbackrest-walg-barman.md
+++ b/docs/explanation/comparison-pgbackrest-walg-barman.md
@@ -26,7 +26,7 @@ The short version of where `pg_hardstorage` differs:
   backup is independently restorable; deleting one cannot break
   another.
 - **Compliance posture (encryption / KMS / audit chain / WORM /
-  FIPS) on by default, no paid tier.**
+  FIPS) on by default.**
 - **3 AM operator UX as a design principle**, not a side effect.
 
 The places `pg_hardstorage` does *not* lead: **production
@@ -91,9 +91,9 @@ The places to think twice:
   incremental can compromise the chain.  CAS backups don't have
   this property.
 
-- **You want strong-default compliance posture without a paid
-  tier.**  pgBackRest's encryption is opt-in; we want it on for
-  every install.
+- **You want strong-default compliance posture.**  pgBackRest's
+  encryption is opt-in; we want it on by default for every
+  install.
 
 ---
 
@@ -172,8 +172,8 @@ differentiation:
   same config schema, same repo schema.  The operator learns one
   tool.
 
-- **Compliance-first posture** without a paid tier.  Encryption,
-  KMS, audit chain, WORM, FIPS, crypto-shred all on by default.
+- **Compliance-first posture.**  Encryption, KMS, audit chain,
+  WORM, FIPS, crypto-shred all on by default.
 
 - **3 AM operator UX as a feature**.  `--preview`, plain-English
   errors with suggested next commands, `doctor`'s per-issue

--- a/docs/explanation/design-principles.md
+++ b/docs/explanation/design-principles.md
@@ -69,19 +69,18 @@ and the [repair toolkit reference](../reference/runbooks/index.md).
 
 ---
 
-## 2. Compliance is a feature, not a tier
+## 2. Compliance is a feature
 
-`pg_hardstorage` is Apache 2.0.  There is no paid edition.
-Encryption, KMS integration, audit log, signed manifests, WORM,
-FIPS, and crypto-shred are *on by default* in the open-source
-binary — not held back behind a license check.
+The base version of `pg_hardstorage` is Apache 2.0.  Encryption,
+KMS integration, audit log, signed manifests, WORM, FIPS, and
+crypto-shred are *on by default* in the open-source binary.
 
-We picked this for two reasons.  First, "compliance as upsell" has
-historically meant that the most security-critical defaults are
-the *worst* ones in the free tier; we refuse to ship that posture.
-Second, audit logs and signed manifests are how the system stays
-honest with its own operators — we want every install, including
-homelabs, to have them.
+We picked this for two reasons.  First, the most security-critical
+defaults should be the *best* ones, not the worst; strong
+compliance behaviour ships in the base build rather than being
+bolted on as an afterthought.  Second, audit logs and signed
+manifests are how the system stays honest with its own operators —
+we want every install, including homelabs, to have them.
 
 Concrete consequences:
 
@@ -90,12 +89,12 @@ Concrete consequences:
   default once a validated implementation lands.  See [envelope
   encryption](envelope-encryption.md).
 
-- The audit log is hash-chained on every write — no opt-in, no
-  feature flag.  The chain is verifiable post-hoc with `audit
-  verify-chain`.  See [the audit chain](audit-chain.md).
+- The audit log is hash-chained on every write, automatically.
+  The chain is verifiable post-hoc with `audit verify-chain`.
+  See [the audit chain](audit-chain.md).
 
-- WORM (Object Lock / immutable blob) is a per-deployment flag,
-  not a tier.
+- WORM (Object Lock / immutable blob) is a per-deployment flag
+    configured on the deployment itself.
 
 - Per-tenant KEKs are mandatory architecture even for single-org
   installs (you get a default tenant you never see).  This makes
@@ -152,8 +151,8 @@ Same binary, same UX, same config file from a 10 GB single-host
 PostgreSQL to a 100+ TB Patroni cluster on Kubernetes.  Big-database
 features (parallel chunk pipeline, snapshot base backups, multiple
 WAL streams from replicas) are *automatic upgrades* the system
-chooses based on database size and topology — they are **not** a
-separate "enterprise mode" the operator has to opt into.
+chooses based on database size and topology — the operator does
+not have to opt into them manually.
 
 The size-tiered defaults table:
 

--- a/docs/explanation/envelope-encryption.md
+++ b/docs/explanation/envelope-encryption.md
@@ -136,7 +136,7 @@ fingerprinting via repeated chunk identity).
 
 Single-org installs get a default tenant they never see — but the
 tenant boundary exists in the data layout regardless.  This is a
-design choice, not a tier:
+deliberate architectural choice, baked into the data layout:
 
 - **GDPR crypto-shred** is `pg_hardstorage kms shred --confirm-keyring <keyring-dir>
   --reason "GDPR Art. 17 request #4421"`.  One key-destruction op.  The

--- a/docs/explanation/wal-pipeline.md
+++ b/docs/explanation/wal-pipeline.md
@@ -210,7 +210,7 @@ Three properties hold across all modes:
   dual-stream config against a single-node cluster is rejected at
   parse time, not at run time.
 
-- **Mode is not a tier.**  Switching from single-stream to
+- **Mode is just configuration.**  Switching from single-stream to
   dual-stream is a config change.  Nothing in the repo schema
   changes; old manifests remain restorable; the new manifests gain
   a second stream's-worth of dedup-coverage and that's all.

--- a/docs/faq.md
+++ b/docs/faq.md
@@ -654,10 +654,11 @@ as the streaming path.
 
 #### What's the license?
 
+The base version is
 [Apache 2.0](https://www.apache.org/licenses/LICENSE-2.0).
-No paid tier, no enterprise edition gate.  Compliance,
-encryption, audit chain, FIPS, HSM, and the LLM helper are
-all in the open-source build.
+Compliance, encryption, audit chain, FIPS, HSM, and the LLM
+helper are available in the open-source build today.  A paid
+tier with additional features is planned.
 
 #### Who owns the project?
 


### PR DESCRIPTION
## Summary
Updates product messaging and positioning across the documentation and `SPEC.md`
to reflect the planned open-core model (Apache 2.0 base version plus a planned
paid tier with additional features), replacing prior statements that asserted
there was no paid tier / no open-core / no feature gating.

## Type
- [ ] Bug fix
- [ ] New feature
- [ ] Refactor (no behaviour change)
- [x] Documentation
- [ ] Test infrastructure
- [ ] Packaging / release

## Tests
- [ ] `make check` passes locally (vet + race tests)
- [x] New tests added for the changed behaviour, or there's a clear reason none exist  <!-- docs/spec-only change; no testable behaviour -->
- [ ] Integration tests pass (`make test-integration`) where touched  <!-- N/A — no code touched -->

## Compatibility
- [x] No on-disk manifest schema changes (or: schema bumped + 24-month back-read preserved)
- [x] No CLI / API contract changes (or: documented + bumped)
- [x] No new external dependencies (or: justified in the description)

## Checklist
- [ ] Maintainer-attribution authoring (`Author: Hans-Jürgen Schönig <hs@cybertec.at>`)
- [x] No AI-attribution lines anywhere
- [ ] CHANGELOG.md updated under the unreleased section
- [x] Comments explain WHY (not WHAT) where the code isn't self-evident  <!-- N/A — no code -->