### PR TITLE
fix: atomic shared-DEK mint — unrestorable encrypted backups under concurrent WAL streaming (#31)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,31 @@ keeps reading that version for at least 24 months after a successor lands.
 
 ## [Unreleased]
 
+### Fix: intermittently unrestorable encrypted backups under concurrent WAL streaming (#31)
+
+With `wal stream` running, a concurrently-taken base `backup` could
+commit a manifest that was silently **unrestorable** — `verify` reported
+mass chunk-integrity failures and `restore` failed with
+`encryption: unknown algorithm: 1`, even though `backup` exited 0.
+
+Root cause was a check-then-act race in the shared-DEK coordination. The
+CAS deduplicates chunks by plaintext hash, so every encrypted artifact
+under one KEK must share one DEK. Resolution only scanned *committed*
+manifests, so two writers that both started before either committed each
+minted a **different** DEK. A PostgreSQL full-page image in WAL that
+chunked to the same bytes as a base-backup file then deduped to one CAS
+slot, stored under one writer's DEK while the other's manifest referenced
+it under the other DEK — undecryptable.
+
+The DEK is now minted through an **atomic single-winner PUT** on a
+well-known shared-DEK object (`keys/shared-dek/<kekref-hash>.json`): the
+first writer wins, every concurrent writer reads back and reuses the
+winner's DEK, so streaming and base backups always converge on one DEK.
+Existing repos are seeded transparently from their manifests on first
+write. Covered by a 24-way concurrent regression test and validated
+end-to-end (streaming + racing backups → all verify + restore cleanly;
+exactly one shared-DEK object).
+
 ## [1.0.12] — 2026-07-16
 
 ### Docs: remove false-capability claims (managed DBaaS + unshipped features)

--- a/internal/backup/runner/dek_reuse.go
+++ b/internal/backup/runner/dek_reuse.go
@@ -22,9 +22,12 @@ import (
 // by an earlier backup OR WAL segment is silently reused (IfNotExists) by
 // this one, and this manifest's DEK has to decrypt it.
 //
-// Resolution scans BOTH base-backup manifests and WAL segment manifests
-// (sharedkey.Resolve), so a backup converges on a DEK that WAL streaming
-// minted first, and vice-versa (issue #106).
+// Resolution goes through sharedkey.ResolveOrMint, which mints the DEK
+// via an atomic single-winner PUT on a well-known shared-DEK object (and
+// seeds that object from existing base-backup / WAL manifests for legacy
+// repos), so a backup converges on the SAME DEK as concurrent WAL
+// streaming even when neither has committed a manifest yet (issues #106,
+// #31) — not just when one committed first.
 //
 // A fresh DEK is correct ONLY when we have positively confirmed there is
 // NO prior DEK for this KEK anywhere. The two failure shapes that must NOT
@@ -35,30 +38,45 @@ import (
 func selectDEK(ctx context.Context, sp storage.StoragePlugin, kekRef string, cfg *EncryptionConfig) ([encryption.KeyLen]byte, error) {
 	var dek [encryption.KeyLen]byte
 
-	res, err := sharedkey.Resolve(ctx, sp, kekRef, func(wrapped []byte) ([]byte, error) {
-		return unwrapDEKForReuse(ctx, cfg, wrapped)
-	})
+	// ResolveOrMint mints the shared DEK atomically (single-winner PUT on
+	// the shared-DEK object), so a backup starting concurrently with `wal
+	// stream` converges on ONE DEK instead of each minting its own — the
+	// old behaviour left deduped WAL/base chunks unrestorable (issue #31).
+	res, err := sharedkey.ResolveOrMint(ctx, sp, kekRef,
+		func(wrapped []byte) ([]byte, error) { return unwrapDEKForReuse(ctx, cfg, wrapped) },
+		func(d [encryption.KeyLen]byte) ([]byte, error) { return wrapDEKForReuse(ctx, cfg, d) },
+	)
 	if err != nil {
-		return dek, fmt.Errorf("backup: cannot determine whether a DEK already exists for KEK %q; refusing a fresh DEK that the CAS's plaintext-hash dedup would leave unrestorable against existing chunks: %w", kekRef, err)
+		return dek, fmt.Errorf("backup: cannot determine or mint the shared DEK for KEK %q; refusing a fresh DEK that the CAS's plaintext-hash dedup would leave unrestorable against existing chunks: %w", kekRef, err)
 	}
-	if res.DEK != nil {
-		if len(res.DEK) != encryption.KeyLen {
-			return dek, fmt.Errorf("backup: reused DEK for KEK %q has wrong length %d (want %d)", kekRef, len(res.DEK), encryption.KeyLen)
-		}
-		copy(dek[:], res.DEK)
-		return dek, nil
-	}
-	if res.SawCandidate {
+	if res.UnusableCandidate {
 		return dek, fmt.Errorf("backup: a prior DEK for KEK %q exists but none of its recorded wrapped form(s) could be unwrapped for reuse; refusing a fresh DEK that would leave deduped chunks unrestorable (verify the KEK material matches this ref)", kekRef)
 	}
-
-	// Positively no prior DEK for this KEK in any backup or WAL manifest —
-	// the first encrypted artifact in this repo. A fresh DEK is correct.
-	fresh, gerr := encryption.GenerateDEK()
-	if gerr != nil {
-		return dek, fmt.Errorf("backup: generate DEK: %w", gerr)
+	if !res.Have {
+		return dek, fmt.Errorf("backup: shared-DEK resolution returned no key for KEK %q", kekRef)
 	}
-	return fresh, nil
+	return res.DEK, nil
+}
+
+// wrapDEKForReuse wraps a plaintext DEK for storage in the shared-DEK
+// object, mirroring unwrapDEKForReuse's custody split (cloud KMS vs local
+// KEK).
+func wrapDEKForReuse(ctx context.Context, cfg *EncryptionConfig, dek [encryption.KeyLen]byte) ([]byte, error) {
+	if cfg == nil {
+		return nil, errors.New("dek-reuse: nil encryption config")
+	}
+	if cfg.Provider != nil {
+		w, err := cfg.Provider.WrapDEK(ctx, dek[:])
+		if err != nil {
+			return nil, fmt.Errorf("dek-reuse: provider wrap: %w", err)
+		}
+		return w, nil
+	}
+	w, err := encryption.Wrap(cfg.KEK, dek)
+	if err != nil {
+		return nil, fmt.Errorf("dek-reuse: local wrap: %w", err)
+	}
+	return w, nil
 }
 
 // looksLikePrimaryManifest returns true for keys of the shape

--- a/internal/cli/wal.go
+++ b/internal/cli/wal.go
@@ -917,10 +917,14 @@ func deploymentBackupKEKRef(ctx context.Context, sp storage.StoragePlugin, deplo
 //   - cloud KMS (cfg.Provider set) — wrap/unwrap via the provider.
 //   - cfg == nil — no encryption configured (no keyring, no --kek): plaintext.
 //
-// The shared DEK is resolved across BOTH base-backup AND prior WAL manifests
-// (sharedkey.Resolve), so whichever writer runs first mints it and the other
-// reuses it, in either order; minting happens only when no prior DEK exists
-// anywhere. A prior DEK that cfg can't unwrap FAILS the write rather than
+// The shared DEK is minted via sharedkey.ResolveOrMint, which serialises
+// the mint through an atomic single-winner PUT on a well-known shared-DEK
+// object (seeded from existing base-backup / WAL manifests for legacy
+// repos). This makes concurrent WAL streaming and base backups converge on
+// ONE DEK even when neither has committed a manifest yet — the earlier
+// scan-then-mint could have each writer mint a DIFFERENT DEK, leaving a
+// full-page image that deduped against a base chunk unrestorable (issue
+// #31). A prior DEK that cfg can't unwrap FAILS the write rather than
 // forking a fresh DEK that would leave deduped chunks unrestorable (issue #28).
 //
 // Divergence guard: if the deployment's established backups use a DIFFERENT
@@ -954,27 +958,24 @@ func buildWALEncryption(ctx context.Context, sp storage.StoragePlugin, deploymen
 		wrap = func(dek [encryption.KeyLen]byte) ([]byte, error) { return encryption.Wrap(kek, dek) }
 	}
 
-	res, rerr := sharedkey.Resolve(ctx, sp, cfg.KEKRef, unwrap)
+	// ResolveOrMint mints the shared DEK atomically (single-winner PUT on
+	// the shared-DEK object), so WAL streaming starting concurrently with a
+	// base backup converges on ONE DEK. The old Resolve-then-mint path let
+	// each writer mint its own DEK when neither had committed a manifest
+	// yet, so a WAL full-page image that dedups against a base chunk was
+	// stored under a different DEK than the backup manifest referenced it
+	// by — leaving the backup unrestorable (issue #31).
+	res, rerr := sharedkey.ResolveOrMint(ctx, sp, cfg.KEKRef, unwrap, wrap)
 	if rerr != nil {
-		return nil, nil, fmt.Errorf("wal: cannot determine the shared DEK; refusing to write WAL that the CAS's plaintext-hash dedup would leave unrestorable: %w", rerr)
+		return nil, nil, fmt.Errorf("wal: cannot determine or mint the shared DEK; refusing to write WAL that the CAS's plaintext-hash dedup would leave unrestorable: %w", rerr)
 	}
-
-	var dek [encryption.KeyLen]byte
-	switch {
-	case res.DEK != nil:
-		if len(res.DEK) != encryption.KeyLen {
-			return nil, nil, fmt.Errorf("wal: reused shared DEK has wrong length %d", len(res.DEK))
-		}
-		copy(dek[:], res.DEK)
-	case res.SawCandidate:
+	if res.UnusableCandidate {
 		return nil, nil, fmt.Errorf("wal: a prior DEK for KEK %q exists but could not be unwrapped; refusing to write WAL under a fresh DEK that would leave deduped chunks unrestorable (verify the KEK material matches this repo)", cfg.KEKRef)
-	default:
-		fresh, gerr := encryption.GenerateDEK()
-		if gerr != nil {
-			return nil, nil, fmt.Errorf("wal: generate DEK: %w", gerr)
-		}
-		dek = fresh
 	}
+	if !res.Have {
+		return nil, nil, fmt.Errorf("wal: shared-DEK resolution returned no key for KEK %q", cfg.KEKRef)
+	}
+	dek := res.DEK
 
 	wrapped, werr := wrap(dek)
 	if werr != nil {

--- a/internal/repo/sharedkey/resolveormint_test.go
+++ b/internal/repo/sharedkey/resolveormint_test.go
@@ -1,0 +1,119 @@
+package sharedkey_test
+
+import (
+	"context"
+	"sync"
+	"testing"
+
+	"github.com/cybertec-postgresql/pg_hardstorage/internal/plugin/encryption"
+	"github.com/cybertec-postgresql/pg_hardstorage/internal/repo/sharedkey"
+)
+
+func wrapperFor(kek [encryption.KeyLen]byte) sharedkey.Wrapper {
+	return func(dek [encryption.KeyLen]byte) ([]byte, error) { return encryption.Wrap(kek, dek) }
+}
+
+// Regression for issue #31: N writers that call ResolveOrMint concurrently
+// against a fresh repo (no prior DEK) MUST all converge on the SAME DEK.
+// The old Resolve-then-mint path had each writer mint its own fresh DEK
+// when neither had committed a manifest yet, so a WAL full-page image that
+// deduped against a base-backup chunk was stored under a different DEK than
+// the backup manifest referenced it by — leaving the backup unrestorable.
+func TestResolveOrMint_ConcurrentWritersConverge(t *testing.T) {
+	const kekRef = "local:default"
+	kek := testKEK(7)
+	unwrap := unwrapperFor(kek)
+	wrap := wrapperFor(kek)
+
+	const N = 24
+	sp := newSP(t) // shared store — all writers race on the same shared-DEK object
+
+	var wg sync.WaitGroup
+	deks := make([][encryption.KeyLen]byte, N)
+	errs := make([]error, N)
+	start := make(chan struct{})
+	for i := 0; i < N; i++ {
+		wg.Add(1)
+		go func(i int) {
+			defer wg.Done()
+			<-start // maximise the race window
+			res, err := sharedkey.ResolveOrMint(context.Background(), sp, kekRef, unwrap, wrap)
+			if err != nil {
+				errs[i] = err
+				return
+			}
+			if !res.Have {
+				t.Errorf("writer %d: no DEK", i)
+				return
+			}
+			deks[i] = res.DEK
+		}(i)
+	}
+	close(start)
+	wg.Wait()
+
+	var want [encryption.KeyLen]byte
+	for i := 0; i < N; i++ {
+		if errs[i] != nil {
+			t.Fatalf("writer %d: %v", i, errs[i])
+		}
+		if i == 0 {
+			want = deks[0]
+			continue
+		}
+		if deks[i] != want {
+			t.Fatalf("writer %d minted a DIVERGENT DEK: %x != %x (issue #31 race)", i, deks[i][:8], want[:8])
+		}
+	}
+	// And a fresh resolve reads back the same committed DEK.
+	res, err := sharedkey.ResolveOrMint(context.Background(), sp, kekRef, unwrap, wrap)
+	if err != nil || !res.Have || res.DEK != want {
+		t.Fatalf("post-hoc resolve = (%x, have=%v, err=%v), want %x", res.DEK[:8], res.Have, err, want[:8])
+	}
+}
+
+// A legacy repo (a committed manifest carries a DEK, but no shared-DEK
+// object exists yet) must ADOPT that manifest DEK, not mint a new one.
+func TestResolveOrMint_AdoptsLegacyManifestDEK(t *testing.T) {
+	const kekRef = "local:default"
+	kek := testKEK(3)
+	sp := newSP(t)
+
+	var legacy [encryption.KeyLen]byte
+	for i := range legacy {
+		legacy[i] = 0xAB
+	}
+	wrapped := mustWrap(t, kek, legacy)
+	putEnvelopeManifest(t, sp, "manifests/db1/backups/b1/manifest.json", kekRef, wrapped)
+
+	res, err := sharedkey.ResolveOrMint(context.Background(), sp, kekRef, unwrapperFor(kek), wrapperFor(kek))
+	if err != nil || !res.Have {
+		t.Fatalf("adopt: err=%v have=%v", err, res.Have)
+	}
+	if res.DEK != legacy {
+		t.Fatalf("adopted DEK = %x, want the legacy manifest DEK %x", res.DEK[:8], legacy[:8])
+	}
+}
+
+// A shared-DEK object wrapped under a DIFFERENT KEK than the caller's must
+// yield UnusableCandidate (fail), never a fresh mint — a fresh DEK would
+// leave existing deduped chunks unrestorable.
+func TestResolveOrMint_WrongKEKIsUnusable(t *testing.T) {
+	const kekRef = "local:default"
+	owner := testKEK(1)
+	stranger := testKEK(9)
+	sp := newSP(t)
+
+	// Owner mints the shared DEK.
+	if _, err := sharedkey.ResolveOrMint(context.Background(), sp, kekRef, unwrapperFor(owner), wrapperFor(owner)); err != nil {
+		t.Fatalf("owner mint: %v", err)
+	}
+	// Stranger (wrong KEK) must not mint a divergent DEK.
+	res, err := sharedkey.ResolveOrMint(context.Background(), sp, kekRef, unwrapperFor(stranger), wrapperFor(stranger))
+	if err != nil {
+		t.Fatalf("stranger: unexpected hard error %v", err)
+	}
+	if res.Have || !res.UnusableCandidate {
+		t.Fatalf("stranger got have=%v unusable=%v, want unusable (must not fork a DEK)", res.Have, res.UnusableCandidate)
+	}
+}

--- a/internal/repo/sharedkey/sharedkey.go
+++ b/internal/repo/sharedkey/sharedkey.go
@@ -15,9 +15,13 @@
 package sharedkey
 
 import (
+	"bytes"
 	"context"
+	"crypto/sha256"
 	"encoding/base64"
+	"encoding/hex"
 	"encoding/json"
+	"errors"
 	"fmt"
 	"io"
 	"strings"
@@ -28,6 +32,43 @@ import (
 
 // Scheme is the only envelope scheme DEK reuse applies to.
 const Scheme = "aes-256-gcm"
+
+// sharedDEKPrefix holds the authoritative shared-DEK object — one per
+// KEKRef. It is the serialization point that makes concurrent minting
+// converge: the manifest scan (Resolve) only sees COMMITTED manifests,
+// so two writers (e.g. `wal stream` + `backup`) that both start before
+// either commits would each mint a DIFFERENT fresh DEK. Full-page images
+// in WAL then dedup against base-backup chunks (same plaintext hash) but
+// are stored under one DEK while the other's manifest references them
+// under the other DEK — leaving a "successful" backup unrestorable
+// (issue #31). Minting the DEK via an atomic IfNotExists PUT on this
+// single object serialises the mint so every writer shares one DEK.
+const sharedDEKPrefix = "keys/shared-dek/"
+
+// Wrapper wraps a plaintext DEK under the caller's KEK custody model —
+// local AES-256-GCM wrap or a cloud-KMS round-trip. Mirror of Unwrapper.
+type Wrapper func(dek [encryption.KeyLen]byte) ([]byte, error)
+
+// MintResult is the outcome of ResolveOrMint.
+type MintResult struct {
+	// DEK is the shared plaintext DEK; valid iff Have is true.
+	DEK [encryption.KeyLen]byte
+	// Have reports that DEK is set (resolved, adopted, or minted).
+	Have bool
+	// UnusableCandidate reports that a prior DEK exists for this KEK
+	// (in the shared-DEK object or a manifest) but none of its wrapped
+	// forms unwrap with the caller's KEK. The caller MUST fail rather
+	// than mint a fresh DEK. Mutually exclusive with Have.
+	UnusableCandidate bool
+}
+
+// sharedDEKKey is the storage key for the shared-DEK object of kekRef.
+// The KEKRef is hashed so any scheme (local:default, aws-kms://arn:...,
+// vault-transit://...) maps to a safe, fixed-width key.
+func sharedDEKKey(kekRef string) string {
+	sum := sha256.Sum256([]byte(kekRef))
+	return sharedDEKPrefix + hex.EncodeToString(sum[:]) + ".json"
+}
 
 // Unwrapper turns a wrapped-DEK blob into the plaintext DEK. It encapsulates
 // the KEK custody model — local AES-256-GCM unwrap or a cloud-KMS round-trip —
@@ -104,6 +145,116 @@ func Resolve(ctx context.Context, sp storage.StoragePlugin, wantKEKRef string, u
 		}
 	}
 	return res, nil
+}
+
+// ResolveOrMint returns the one shared DEK every encrypted artifact under
+// (repo, kekRef) must use, minting it atomically the first time so that
+// concurrent writers never diverge (issue #31).
+//
+// Order of resolution:
+//
+//  1. The authoritative shared-DEK object. Present + unwraps -> use it.
+//     Present + won't unwrap -> UnusableCandidate (wrong KEK; caller fails).
+//  2. Legacy repos (written before this object existed): scan committed
+//     manifests via Resolve. A reusable DEK is ADOPTED into the shared-DEK
+//     object (best-effort, IfNotExists) and returned. A manifest DEK that
+//     won't unwrap -> UnusableCandidate.
+//  3. Truly no prior DEK anywhere: generate a fresh DEK, wrap it, and PUT
+//     the shared-DEK object with IfNotExists. If we win, use the fresh DEK.
+//     If we lose (ErrAlreadyExists — a concurrent writer minted first), we
+//     re-read the winner's object and use THAT DEK. This atomic single
+//     winner is the whole fix: the old code had each writer mint its own.
+//
+// A hard storage error is returned as err so the caller fails rather than
+// mistaking "couldn't coordinate" for "no DEK exists".
+func ResolveOrMint(ctx context.Context, sp storage.StoragePlugin, kekRef string, unwrap Unwrapper, wrap Wrapper) (MintResult, error) {
+	key := sharedDEKKey(kekRef)
+
+	// 1. Authoritative object.
+	if wrapped, ok := readWrappedDEK(ctx, sp, key, kekRef); ok {
+		return unwrapInto(wrapped, unwrap)
+	}
+
+	// 2. Legacy seed: adopt an existing manifest DEK.
+	res, err := Resolve(ctx, sp, kekRef, unwrap)
+	if err != nil {
+		return MintResult{}, err
+	}
+	if res.DEK != nil {
+		var out MintResult
+		if len(res.DEK) != encryption.KeyLen {
+			return MintResult{}, fmt.Errorf("sharedkey: adopted DEK has wrong length %d (want %d)", len(res.DEK), encryption.KeyLen)
+		}
+		copy(out.DEK[:], res.DEK)
+		out.Have = true
+		// Best-effort promotion so future writers skip the manifest scan
+		// and, more importantly, so a later concurrent fresh-mint can't
+		// race in a divergent DEK. A conflict here is fine — someone else
+		// adopted the same manifest DEK.
+		if wrapped, werr := wrap(out.DEK); werr == nil {
+			_ = putSharedDEK(ctx, sp, key, kekRef, wrapped)
+		}
+		return out, nil
+	}
+	if res.SawCandidate {
+		return MintResult{UnusableCandidate: true}, nil
+	}
+
+	// 3. Atomic fresh mint.
+	fresh, gerr := encryption.GenerateDEK()
+	if gerr != nil {
+		return MintResult{}, fmt.Errorf("sharedkey: generate DEK: %w", gerr)
+	}
+	wrapped, werr := wrap(fresh)
+	if werr != nil {
+		return MintResult{}, fmt.Errorf("sharedkey: wrap fresh DEK: %w", werr)
+	}
+	perr := putSharedDEK(ctx, sp, key, kekRef, wrapped)
+	if perr == nil {
+		return MintResult{DEK: fresh, Have: true}, nil // we minted it
+	}
+	if !errors.Is(perr, storage.ErrAlreadyExists) {
+		return MintResult{}, fmt.Errorf("sharedkey: commit shared DEK: %w", perr)
+	}
+	// Lost the mint race — adopt the winner's DEK. This is exactly the
+	// path that used to (incorrectly) keep the loser's own fresh DEK.
+	winner, ok := readWrappedDEK(ctx, sp, key, kekRef)
+	if !ok {
+		return MintResult{}, fmt.Errorf("sharedkey: shared DEK object present after IfNotExists conflict but unreadable for KEK %q", kekRef)
+	}
+	return unwrapInto(winner, unwrap)
+}
+
+// unwrapInto unwraps a shared-DEK wrapped form into a MintResult. A wrap
+// that won't authenticate under the caller's KEK yields UnusableCandidate
+// (a prior DEK exists but this KEK can't read it) rather than an error.
+func unwrapInto(wrapped []byte, unwrap Unwrapper) (MintResult, error) {
+	dek, uerr := unwrap(wrapped)
+	if uerr != nil || len(dek) != encryption.KeyLen {
+		return MintResult{UnusableCandidate: true}, nil
+	}
+	var out MintResult
+	copy(out.DEK[:], dek)
+	out.Have = true
+	return out, nil
+}
+
+// putSharedDEK writes the shared-DEK envelope at key with IfNotExists, so
+// only the first writer wins. Returns storage.ErrAlreadyExists on conflict.
+func putSharedDEK(ctx context.Context, sp storage.StoragePlugin, key, kekRef string, wrapped []byte) error {
+	body, err := json.Marshal(manifestEnvelope{Encryption: &envelope{
+		Scheme:     Scheme,
+		KEKRef:     kekRef,
+		WrappedDEK: base64.StdEncoding.EncodeToString(wrapped),
+	}})
+	if err != nil {
+		return err
+	}
+	_, err = sp.Put(ctx, key, bytes.NewReader(body), storage.PutOptions{
+		IfNotExists:   true,
+		ContentLength: int64(len(body)),
+	})
+	return err
 }
 
 // isManifestKey reports whether key under prefix is a manifest worth reading


### PR DESCRIPTION
Fixes #31 — intermittently unrestorable encrypted base backups when `wal stream` runs concurrently with `backup`.

## Root cause
A check-then-act race in the shared-DEK coordination. The CAS deduplicates chunks by **plaintext** hash, so every encrypted artifact under one KEK must share one DEK. Both writers — backup's `selectDEK` and WAL's `buildWALEncryption` — resolved the DEK by scanning only **committed** manifests (`sharedkey.Resolve`) and minted a fresh DEK when none was found. Two writers that both started before either committed each minted a **different** DEK; a PostgreSQL full-page image in WAL that chunked to the same bytes as a base-backup file then deduped to one CAS slot — stored under one writer's DEK while the other's manifest referenced it under the other. Result: `verify` mass chunk-mismatch, `restore` → `encryption: unknown algorithm: 1`, while `backup` exited 0.

## Fix
`sharedkey.ResolveOrMint` mints the DEK via an **atomic single-winner `IfNotExists` PUT** on a well-known object `keys/shared-dek/<sha256(kekref)>.json`:
- present + unwraps → reuse;
- absent → generate, wrap, PUT-if-not-exists — **winner keeps its DEK; every loser reads back and reuses the winner's**;
- legacy repos (DEK only in manifests) are seeded into the object on first write;
- a prior DEK the caller's KEK can't unwrap still **fails loudly** (never forks a fresh DEK — issue #28 posture preserved).

Both callers switched to `ResolveOrMint`; no path bypasses it.

## Validation
- **24-way concurrent regression test under `-race`** — all writers converge on one DEK (`TestResolveOrMint_ConcurrentWritersConverge`); plus legacy-adopt and wrong-KEK-unusable tests.
- **End-to-end repro** (the issue's scenario): encrypted repo (local KEK, aes-256-gcm), `wal stream` running, 5 racing `backup` invocations with heavy full-page-image churn → every backup `verify --full` **passes**, `restore` → **"✓ Restore complete"**, and exactly **one** shared-DEK object exists. The `unknown algorithm: 1` / chunk-mismatch symptoms are gone.
- Full unit suite green; `go vet` clean.

Ships in the next release; CHANGELOG updated under Unreleased.
