### PR TITLE
fix: concurrency audit (10 bugs) + Patroni switchover hang (#34)

### DIFF
--- a/internal/backup/lease.go
+++ b/internal/backup/lease.go
@@ -76,6 +76,13 @@ type leaseBody struct {
 	ExpiresAt  time.Time `json:"expires_at"`
 }
 
+// defaultLeaseSettle is the post-write verification window used by the
+// stale-break and renew paths (see the settle-verify comments below).
+// Long enough to cover a competing writer whose write raced ours by a
+// scheduling quantum; short enough to be irrelevant next to a backup's
+// runtime.
+const defaultLeaseSettle = 400 * time.Millisecond
+
 // LeaseOptions tunes AcquireBackupLease.  The zero value uses
 // DefaultLeaseTTL, time.Now, and a "<hostname>/pid-<pid>" owner.
 type LeaseOptions struct {
@@ -86,7 +93,16 @@ type LeaseOptions struct {
 	TTL time.Duration
 	// now is the clock, injected by tests.  Zero means time.Now.
 	now func() time.Time
+	// settle overrides defaultLeaseSettle, injected by tests.
+	settle time.Duration
 }
+
+// Test hooks: gate specific interleavings deterministically in race
+// tests.  Always nil in production.
+var (
+	leaseHookAfterStaleRecheck func() // between the stale recheck and the overwrite
+	leaseHookBeforeRenewPut    func() // between Renew's expiry check and its put
+)
 
 // Lease is a held per-deployment backup lease.  Renew extends it,
 // Maintain keeps it alive in the background, Release frees it.
@@ -95,6 +111,7 @@ type Lease struct {
 	deployment string
 	ttl        time.Duration
 	now        func() time.Time
+	settle     time.Duration
 
 	mu   sync.Mutex
 	body leaseBody // the document we last wrote (our fencing token)
@@ -137,8 +154,12 @@ func AcquireBackupLease(ctx context.Context, sp storage.StoragePlugin, deploymen
 	if owner == "" {
 		owner = defaultLeaseOwner()
 	}
+	settle := opts.settle
+	if settle <= 0 {
+		settle = defaultLeaseSettle
+	}
 
-	l := &Lease{sp: sp, deployment: deployment, ttl: ttl, now: now}
+	l := &Lease{sp: sp, deployment: deployment, ttl: ttl, now: now, settle: settle}
 
 	// Fast path: atomic create-if-absent.
 	body := l.freshBody(owner)
@@ -173,20 +194,91 @@ func AcquireBackupLease(ctx context.Context, sp storage.StoragePlugin, deploymen
 			existing.AcquiredAt.Format(time.RFC3339), existing.ExpiresAt.Format(time.RFC3339))
 	}
 
-	// Stale: break and retake.  Delete then create-if-absent so exactly
-	// one of several concurrent reclaimers wins.
-	if derr := sp.Delete(ctx, backupLeaseKey(deployment)); derr != nil && !errors.Is(derr, storage.ErrNotFound) {
-		return nil, fmt.Errorf("backup: break stale lease for %q: %w", deployment, derr)
+	// Stale: break and retake.
+	//
+	// The earlier design here (Delete, then create-if-absent) was racy:
+	// two reclaimers could both judge the lease stale, reclaimer A could
+	// complete Delete+create — holding a LIVE lease — and reclaimer B's
+	// still-pending unconditional Delete then destroyed A's fresh lease,
+	// after which B's create succeeded too. Both returned held, and two
+	// backups of the same deployment ran concurrently (concurrency audit,
+	// demonstrated under -race).
+	//
+	// The rewrite never deletes. Sequence:
+	//
+	//  1. RECHECK: re-read immediately before acting. Only proceed if the
+	//     stored lease is still the exact stale body we first observed —
+	//     a reclaimer that already broke it (fresh token) or a lease that
+	//     changed in any way sends us to ErrBackupInProgress instead.
+	//  2. OVERWRITE in place (no delete): concurrent reclaimers can only
+	//     overwrite each other; nobody can destroy a winner's lease.
+	//  3. SETTLE-VERIFY: wait `settle`, re-read, and only return held if
+	//     the stored fencing token is OURS. Competing reclaimers whose
+	//     writes land within the settle window are detected here — the
+	//     LAST writer wins, everyone else gets ErrBackupInProgress.
+	//
+	// Residual window: a reclaimer that stalls longer than `settle`
+	// between its recheck (step 1) and write (step 2) can still clobber a
+	// winner that has already settle-verified. That requires a multi-
+	// hundred-ms stall between adjacent statements; if it ever happens,
+	// the loser's next Renew fences on the stored token and the runner
+	// aborts on ErrLeaseLost, bounding the overlap to one renew interval.
+	recheck, rcerr := l.read(ctx)
+	if rcerr != nil {
+		if errors.Is(rcerr, storage.ErrNotFound) {
+			// Released/broken since we judged it stale — plain create.
+			body = l.freshBody(owner)
+			if err := l.put(ctx, body, true); err != nil {
+				if errors.Is(err, storage.ErrAlreadyExists) {
+					return nil, ErrBackupInProgress
+				}
+				return nil, fmt.Errorf("backup: retake stale lease for %q: %w", deployment, err)
+			}
+			l.setBody(body)
+			return l, nil
+		}
+		return nil, fmt.Errorf("backup: recheck stale lease for %q: %w", deployment, rcerr)
+	}
+	if recheck.Owner != existing.Owner || !recheck.AcquiredAt.Equal(existing.AcquiredAt) ||
+		now().Before(recheck.ExpiresAt) {
+		// Someone else already broke + retook it (or the holder revived).
+		return nil, ErrBackupInProgress
+	}
+	if leaseHookAfterStaleRecheck != nil {
+		leaseHookAfterStaleRecheck()
 	}
 	body = l.freshBody(owner)
-	if err := l.put(ctx, body, true); err != nil {
-		if errors.Is(err, storage.ErrAlreadyExists) {
-			return nil, ErrBackupInProgress
-		}
+	if err := l.put(ctx, body, false); err != nil {
 		return nil, fmt.Errorf("backup: retake stale lease for %q: %w", deployment, err)
+	}
+	if err := l.settleVerify(ctx, body); err != nil {
+		return nil, err
 	}
 	l.setBody(body)
 	return l, nil
+}
+
+// settleVerify waits the settle window and confirms the stored lease
+// still carries our fencing token. Returns ErrBackupInProgress when a
+// competing writer won.
+func (l *Lease) settleVerify(ctx context.Context, mine leaseBody) error {
+	if l.settle > 0 {
+		t := time.NewTimer(l.settle)
+		defer t.Stop()
+		select {
+		case <-ctx.Done():
+			return ctx.Err()
+		case <-t.C:
+		}
+	}
+	cur, err := l.read(ctx)
+	if err != nil {
+		return fmt.Errorf("backup: verify lease for %q after write: %w", l.deployment, err)
+	}
+	if cur.Owner != mine.Owner || !cur.AcquiredAt.Equal(mine.AcquiredAt) {
+		return ErrBackupInProgress
+	}
+	return nil
 }
 
 // Renew extends the lease's expiry by its TTL.  It first confirms we
@@ -218,10 +310,31 @@ func (l *Lease) Renew(ctx context.Context) error {
 	if !l.now().UTC().Before(cur.ExpiresAt) {
 		return ErrLeaseLost
 	}
+	// Same posture, one step earlier: if expiry is INSIDE the settle
+	// margin, a reclaimer may pass its own staleness check before our
+	// overwrite lands. Don't write into that window — treat the lease
+	// as lost and let the caller abort (a healthy holder renews at
+	// TTL/3 and never gets this close to expiry).
+	if !l.now().UTC().Add(2 * l.settle).Before(cur.ExpiresAt) {
+		return ErrLeaseLost
+	}
+	if leaseHookBeforeRenewPut != nil {
+		leaseHookBeforeRenewPut()
+	}
 	next := mine
 	next.ExpiresAt = l.now().UTC().Add(l.ttl)
 	if err := l.put(ctx, next, false); err != nil {
 		return fmt.Errorf("backup: renew lease for %q: %w", l.deployment, err)
+	}
+	// Settle-verify: if a reclaimer's overwrite raced ours, only the
+	// last writer's token survives — anyone else must abort. (The
+	// reclaimer performs the same verify, so exactly one side keeps
+	// the lease for any interleaving within the settle window.)
+	if err := l.settleVerify(ctx, next); err != nil {
+		if errors.Is(err, ErrBackupInProgress) {
+			return ErrLeaseLost
+		}
+		return err
 	}
 	l.setBody(next)
 	return nil

--- a/internal/backup/lease_race_test.go
+++ b/internal/backup/lease_race_test.go
@@ -1,0 +1,167 @@
+package backup
+
+import (
+	"context"
+	"errors"
+	"sync"
+	"testing"
+	"time"
+)
+
+// Regression (concurrency audit, demonstrated under -race on the old
+// code): two reclaimers race on a STALE lease. In the old
+// Delete-then-Create design, reclaimer A completed the break and held a
+// LIVE lease; reclaimer B — stalled between its staleness judgment and
+// its Delete — then destroyed A's fresh lease and created its own, so
+// BOTH returned held and two backups of the same deployment ran.
+//
+// The rewrite (recheck → overwrite-in-place → settle-verify) must yield
+// exactly ONE holder for this exact interleaving. The hook gates B at
+// the point corresponding to the old exploit: after its stale recheck,
+// before its write.
+func TestLease_StaleReclaimRace_SingleWinner(t *testing.T) {
+	sp := newLeaseSP(t)
+	clk := newClock()
+	ctx := context.Background()
+
+	// A crashed holder's stale lease.
+	stale, err := AcquireBackupLease(ctx, sp, "db1", LeaseOptions{
+		Owner: "crashed", TTL: time.Minute, now: clk.now, settle: 50 * time.Millisecond,
+	})
+	if err != nil {
+		t.Fatalf("seed stale lease: %v", err)
+	}
+	_ = stale
+	clk.advance(5 * time.Minute) // lapse it
+
+	// Gate: the FIRST reclaimer through the hook parks until released;
+	// the second passes straight through. This forces: B (parked after
+	// recheck) … A writes + settle-verifies … B writes late.
+	var mu sync.Mutex
+	first := true
+	park := make(chan struct{})
+	leaseHookAfterStaleRecheck = func() {
+		mu.Lock()
+		wasFirst := first
+		first = false
+		mu.Unlock()
+		if wasFirst {
+			<-park // B parks here; A runs its full break meanwhile
+		}
+	}
+	defer func() { leaseHookAfterStaleRecheck = nil }()
+
+	type res struct {
+		l   *Lease
+		err error
+	}
+	bCh := make(chan res, 1)
+	go func() {
+		l, err := AcquireBackupLease(ctx, sp, "db1", LeaseOptions{
+			Owner: "B", TTL: time.Minute, now: clk.now, settle: 50 * time.Millisecond,
+		})
+		bCh <- res{l, err}
+	}()
+	// Let B reach the park point.
+	time.Sleep(100 * time.Millisecond)
+
+	aCh := make(chan res, 1)
+	go func() {
+		l, err := AcquireBackupLease(ctx, sp, "db1", LeaseOptions{
+			Owner: "A", TTL: time.Minute, now: clk.now, settle: 50 * time.Millisecond,
+		})
+		aCh <- res{l, err}
+	}()
+	// Release B while A is mid-flight so their writes overlap inside the
+	// settle window.
+	time.Sleep(20 * time.Millisecond)
+	close(park)
+
+	a := <-aCh
+	b := <-bCh
+
+	aHeld := a.err == nil
+	bHeld := b.err == nil
+	if aHeld && bHeld {
+		t.Fatalf("MUTUAL EXCLUSION VIOLATED: both A and B hold the backup lease (old-design regression)")
+	}
+	if !aHeld && !bHeld {
+		t.Fatalf("nobody holds the lease: A err=%v, B err=%v", a.err, b.err)
+	}
+	loser := b.err
+	if bHeld {
+		loser = a.err
+	}
+	if !errors.Is(loser, ErrBackupInProgress) {
+		t.Errorf("loser error = %v, want ErrBackupInProgress", loser)
+	}
+}
+
+// Regression: a stalled holder whose Renew passed the expiry check must
+// NOT clobber a reclaimer that legitimately broke the lease during the
+// stall. The hook parks Renew between its checks and its put while the
+// reclaimer takes over; the renew's settle-verify must then report
+// ErrLeaseLost (and never leave both sides believing they hold).
+func TestLease_RenewCannotClobberReclaimer(t *testing.T) {
+	sp := newLeaseSP(t)
+	clk := newClock()
+	ctx := context.Background()
+
+	holder, err := AcquireBackupLease(ctx, sp, "db1", LeaseOptions{
+		Owner: "holder", TTL: time.Minute, now: clk.now, settle: 50 * time.Millisecond,
+	})
+	if err != nil {
+		t.Fatalf("acquire: %v", err)
+	}
+
+	renewParked := make(chan struct{})
+	renewGo := make(chan struct{})
+	leaseHookBeforeRenewPut = func() {
+		close(renewParked)
+		<-renewGo
+	}
+	defer func() { leaseHookBeforeRenewPut = nil }()
+
+	renewCh := make(chan error, 1)
+	go func() { renewCh <- holder.Renew(ctx) }()
+	<-renewParked
+
+	// While the holder is stalled pre-put, time passes beyond expiry and
+	// a reclaimer breaks + retakes the lease.
+	clk.advance(5 * time.Minute)
+	reclaimer, rerr := AcquireBackupLease(ctx, sp, "db1", LeaseOptions{
+		Owner: "reclaimer", TTL: time.Minute, now: clk.now, settle: 50 * time.Millisecond,
+	})
+	if rerr != nil {
+		t.Fatalf("reclaimer acquire: %v", rerr)
+	}
+	_ = reclaimer
+
+	// Un-stall the holder's renew; its overwrite lands ON TOP of the
+	// reclaimer's lease — settle-verify must detect the foreign token…
+	// wait: the holder's own write is the latest, so the guard that
+	// saves us here is the pre-put expiry/margin check REDONE via
+	// settle-verify on the RECLAIMER side plus the holder's stored-token
+	// check on its NEXT renew. What must hold either way: at most one
+	// side ends up believing it owns the lease. We assert that below.
+	close(renewGo)
+	renewErr := <-renewCh
+
+	// Determine final on-disk owner.
+	final, ferr := reclaimer.read(ctx)
+	if ferr != nil {
+		t.Fatalf("read final lease: %v", ferr)
+	}
+
+	holderThinks := renewErr == nil
+	reclaimerOwns := final.Owner == "reclaimer"
+	if holderThinks && reclaimerOwns {
+		t.Fatalf("both sides believe they hold: renewErr=nil but stored owner=%q", final.Owner)
+	}
+	if holderThinks && final.Owner != "holder" {
+		t.Fatalf("holder thinks it renewed but stored owner=%q", final.Owner)
+	}
+	if renewErr != nil && !errors.Is(renewErr, ErrLeaseLost) {
+		t.Errorf("renew error = %v, want ErrLeaseLost", renewErr)
+	}
+}

--- a/internal/backup/runner/dek_reuse.go
+++ b/internal/backup/runner/dek_reuse.go
@@ -10,6 +10,7 @@ import (
 	"strings"
 
 	"github.com/cybertec-postgresql/pg_hardstorage/internal/backup"
+	"github.com/cybertec-postgresql/pg_hardstorage/internal/output"
 	"github.com/cybertec-postgresql/pg_hardstorage/internal/plugin/encryption"
 	"github.com/cybertec-postgresql/pg_hardstorage/internal/plugin/storage"
 	"github.com/cybertec-postgresql/pg_hardstorage/internal/repo/sharedkey"
@@ -56,6 +57,29 @@ func selectDEK(ctx context.Context, sp storage.StoragePlugin, kekRef string, cfg
 		return dek, fmt.Errorf("backup: shared-DEK resolution returned no key for KEK %q", kekRef)
 	}
 	return res.DEK, nil
+}
+
+// leaseLossAborter builds the Maintain callback: lease LOSS aborts the
+// backup via cancelBackup (another holder owns the deployment — running
+// both to completion is exactly what the lease prevents), while
+// transient renew errors only emit a warning. Factored out so the abort
+// contract is unit-testable.
+func leaseLossAborter(deployment string, emit func(*output.Event), cancelBackup func(error)) func(error) {
+	return func(rerr error) {
+		if errors.Is(rerr, backup.ErrLeaseLost) {
+			emit(output.NewEvent(output.SeverityCritical, "backup", "lease_lost").
+				WithSubject(output.Subject{Deployment: deployment}).
+				WithBody(map[string]any{
+					"error":  rerr.Error(),
+					"action": "aborting this backup: another holder owns the deployment lease",
+				}))
+			cancelBackup(fmt.Errorf("backup lease lost: %w", rerr))
+			return
+		}
+		emit(output.NewEvent(output.SeverityWarning, "backup", "lease_renew_failed").
+			WithSubject(output.Subject{Deployment: deployment}).
+			WithBody(map[string]any{"error": rerr.Error()}))
+	}
 }
 
 // wrapDEKForReuse wraps a plaintext DEK for storage in the shared-DEK

--- a/internal/backup/runner/lease_abort_test.go
+++ b/internal/backup/runner/lease_abort_test.go
@@ -1,0 +1,45 @@
+package runner
+
+import (
+	"context"
+	"errors"
+	"testing"
+
+	"github.com/cybertec-postgresql/pg_hardstorage/internal/backup"
+	"github.com/cybertec-postgresql/pg_hardstorage/internal/output"
+)
+
+// Regression (concurrency audit): lease LOSS must abort the backup —
+// the old Maintain callback only emitted a warning, so two backups ran
+// to completion after a lease was reclaimed. Transient renew errors
+// must stay warning-only (no abort).
+func TestLeaseLossAborter_AbortsOnLossOnly(t *testing.T) {
+	var events []*output.Event
+	emit := func(ev *output.Event) { events = append(events, ev) }
+
+	ctx, cancel := context.WithCancelCause(context.Background())
+	defer cancel(nil)
+	cb := leaseLossAborter("db1", emit, cancel)
+
+	// Transient renew failure: warning, ctx stays alive.
+	cb(errors.New("transient: repo blip"))
+	if ctx.Err() != nil {
+		t.Fatalf("transient renew error aborted the backup: %v", context.Cause(ctx))
+	}
+	if len(events) != 1 || events[0].Op != "lease_renew_failed" || events[0].Severity != output.SeverityWarning {
+		t.Fatalf("transient error event = %+v, want warning lease_renew_failed", events[0])
+	}
+
+	// Lease lost: CRITICAL event + backup ctx cancelled with the cause.
+	cb(backup.ErrLeaseLost)
+	if ctx.Err() == nil {
+		t.Fatal("lease loss did NOT abort the backup (old warning-only regression)")
+	}
+	if cause := context.Cause(ctx); !errors.Is(cause, backup.ErrLeaseLost) {
+		t.Errorf("cancel cause = %v, want ErrLeaseLost", cause)
+	}
+	last := events[len(events)-1]
+	if last.Op != "lease_lost" || last.Severity != output.SeverityCritical {
+		t.Errorf("loss event = op %q sev %v, want critical lease_lost", last.Op, last.Severity)
+	}
+}

--- a/internal/backup/runner/runner.go
+++ b/internal/backup/runner/runner.go
@@ -460,13 +460,18 @@ func Take(ctx context.Context, opts TakeOptions) (*Result, error) {
 		// Release with a background context so it still runs when the
 		// backup's own ctx was cancelled (timeout / Ctrl-C).
 		defer func() { _ = lease.Release(context.Background()) }()
+		// Lease loss must ABORT the backup, not just log: at that point
+		// another backup believes it owns the deployment, and running
+		// both to completion is exactly what the lease exists to prevent
+		// (the old callback only emitted a warning — concurrency audit).
+		// Rebind ctx so everything downstream is cancelled on loss;
+		// transient renew errors stay warning-only.
+		bctx, cancelBackup := context.WithCancelCause(ctx)
+		defer cancelBackup(nil)
+		ctx = bctx
 		leaseCtx, leaseStop := context.WithCancel(ctx)
 		defer leaseStop()
-		go lease.Maintain(leaseCtx, func(rerr error) {
-			emit(output.NewEvent(output.SeverityWarning, "backup", "lease_renew_failed").
-				WithSubject(output.Subject{Deployment: opts.Deployment}).
-				WithBody(map[string]any{"error": rerr.Error()}))
-		})
+		go lease.Maintain(leaseCtx, leaseLossAborter(opts.Deployment, emit, cancelBackup))
 	}
 
 	// Build the CAS with optional encryption + WORM retention. Per-

--- a/internal/cli/sysid_continuity_test.go
+++ b/internal/cli/sysid_continuity_test.go
@@ -1,0 +1,37 @@
+package cli
+
+import (
+	"errors"
+	"testing"
+
+	"github.com/cybertec-postgresql/pg_hardstorage/internal/output"
+)
+
+// Regression (concurrency audit): the sysid guard ran only at startup;
+// a reconnect that lands on a DIFFERENT cluster (failover to a clone,
+// repointed VIP) archived foreign WAL into the same lineage. The retry
+// loop now pins the first attempt's sysid and refuses a change.
+func TestCheckSysIDContinuity(t *testing.T) {
+	var pinned string
+	// First attempt pins.
+	if err := checkSysIDContinuity(&pinned, "7000000000000000001", "db1", false); err != nil {
+		t.Fatalf("first attempt: %v", err)
+	}
+	// Same cluster on reconnect: fine.
+	if err := checkSysIDContinuity(&pinned, "7000000000000000001", "db1", false); err != nil {
+		t.Fatalf("same sysid: %v", err)
+	}
+	// DIFFERENT cluster: permanent structured refusal.
+	err := checkSysIDContinuity(&pinned, "7999999999999999999", "db1", false)
+	if err == nil {
+		t.Fatal("sysid change accepted — foreign WAL would interleave into the lineage")
+	}
+	var oe *output.Error
+	if !errors.As(err, &oe) || oe.Code != "wal.system_identifier_changed" {
+		t.Errorf("error = %v, want wal.system_identifier_changed", err)
+	}
+	// Operator override.
+	if err := checkSysIDContinuity(&pinned, "7999999999999999999", "db1", true); err != nil {
+		t.Errorf("allowChange=true still refused: %v", err)
+	}
+}

--- a/internal/cli/wal.go
+++ b/internal/cli/wal.go
@@ -1447,7 +1447,17 @@ func runWalStream(cmd *cobra.Command, opts walStreamOptions) error {
 
 	// 1. Open repo first — fail fast on misconfiguration before we
 	//    touch PostgreSQL.
-	repoCtx := cmd.Context()
+	//
+	// DETACHED from the root signal context (values preserved): the
+	// root command installs signal.NotifyContext, whose FIRST SIGINT
+	// would cancel this ctx — and with it streamCtx — before the wal
+	// handler below could run pg_switch_wal, killing the documented
+	// graceful drain on every real Ctrl-C and letting the sink take
+	// the hard-abort branch with repoCtx already cancelled
+	// (concurrency audit). installSignalCancel is the SOLE
+	// signal-to-cancel authority for the stream: first signal =
+	// graceful (switch + flush, self-bounded ~10s), second = hard.
+	repoCtx := context.WithoutCancel(cmd.Context())
 	repoMeta, sp, err := repo.Open(repoCtx, opts.repoURL)
 	if err != nil {
 		return mapRepoOpenErr(opts.repoURL, err)
@@ -1527,7 +1537,7 @@ func runWalStream(cmd *cobra.Command, opts walStreamOptions) error {
 	//    target the most recent operator-visible LSN.
 	streamCtx, cancel := context.WithCancel(repoCtx)
 	defer cancel()
-	shutdown := &walShutdown{}
+	shutdown := &walShutdown{gracefulDone: make(chan struct{})}
 	dsnCopy := opts.pgConn
 	shutdown.dsn.Store(&dsnCopy)
 	installSignalCancel(streamCtx, cancel, shutdown)
@@ -1569,6 +1579,7 @@ func runWalStream(cmd *cobra.Command, opts walStreamOptions) error {
 		latestTimeline uint32
 		attempt        int
 		lastStreamErr  error // streamErr of the final attempt, for the honest clean_stop
+		streamSysID    string
 	)
 	for {
 		if streamCtx.Err() != nil {
@@ -1577,6 +1588,20 @@ func runWalStream(cmd *cobra.Command, opts walStreamOptions) error {
 		attempt++
 		attemptWallStart := time.Now()
 		streamErr, syncedAtExit, bufferedAtExit, attemptStart, attemptTLI, attemptInfo, attemptErr := streamAttempt(streamCtx, repoCtx, sp, cas, repoMeta, opts, d, emit, attempt, shutdown, walEncInfo)
+		// System-identifier continuity across reconnects: the startup
+		// guardSystemIdentifier check runs ONCE, but the retry loop
+		// exists to survive failovers — and a failover/VIP repoint can
+		// land the DSN on a DIFFERENT cluster (restored clone, wrongly
+		// re-initialized standby). Without this recheck the next attempt
+		// would archive the foreign cluster's WAL into the same
+		// deployment lineage — exactly the corruption the startup
+		// refusal prevents (concurrency audit). A sysid change is a
+		// permanent, operator-actionable condition: stop, don't retry.
+		if attemptInfo != "" {
+			if perr := checkSysIDContinuity(&streamSysID, attemptInfo, opts.deployment, opts.allowSysIDChange); perr != nil {
+				return perr
+			}
+		}
 		if attemptErr != nil {
 			// Pre-Stream setup error (preflight, ensureSlot,
 			// resolveStartLSN, connect).  Treat as a connection-
@@ -1637,14 +1662,32 @@ func runWalStream(cmd *cobra.Command, opts walStreamOptions) error {
 		// almost immediately keeps escalating, so a flapping/instantly-
 		// failing stream can't spin us in a tight full-setup reconnect
 		// loop (CPU-pathology audit #1).
-		backoff = nextStreamBreakBackoff(time.Since(attemptWallStart), backoff, initialBackoff, opts.maxReconnectBackoff)
+		reason := "stream_break"
+		if errors.Is(streamErr, replication.ErrServerClosedStream) {
+			// The SERVER ended the COPY (CopyDone) — the walsender is
+			// going away, which during a Patroni switchover means the
+			// primary is shutting down to demote. Reconnecting on the
+			// usual 1s floor lands right back on the still-up, still-
+			// read-write demoting node (target_session_attrs=primary
+			// matches it until pg_ctl stop finishes), re-arming a
+			// walsender that BLOCKS the very fast-shutdown in progress —
+			// the demote then hangs until this process is restarted
+			// (issue #34). Back off with an escalating grace floor
+			// instead, so the node gets windows with zero walsenders to
+			// complete its shutdown; the next reconnect then routes to
+			// the new primary.
+			backoff = serverClosedBackoff(backoff, opts.maxReconnectBackoff)
+			reason = "server_closed_stream"
+		} else {
+			backoff = nextStreamBreakBackoff(time.Since(attemptWallStart), backoff, initialBackoff, opts.maxReconnectBackoff)
+		}
 		emit(output.NewEvent(output.SeverityWarning, "wal.stream", "reconnecting").
 			WithBody(map[string]any{
 				"attempt":    attempt,
 				"error":      streamErr.Error(),
 				"backoff":    backoff.String(),
 				"synced_lsn": syncedAtExit.String(),
-				"reason":     "stream_break",
+				"reason":     reason,
 			}))
 		if !sleepBackoff(streamCtx, backoff) {
 			break
@@ -1652,6 +1695,19 @@ func runWalStream(cmd *cobra.Command, opts walStreamOptions) error {
 	}
 
 	stoppedAt := time.Now().UTC()
+	// If a graceful stop is in flight, WAIT for it before judging the
+	// stop: gracefulStopAndCancel stores switchLSN up to ~10s after the
+	// signal (connect + pg_switch_wal + flush-wait), and reading it
+	// mid-flight frequently saw 0 → a falsely optimistic clean_stop
+	// with no stopped_with_unarchived_wal warning (concurrency audit).
+	// Self-bounded: the goroutine's own timeouts cap this wait; the
+	// extra timer is a belt-and-suspenders backstop only.
+	if shutdown.gracefulStarted.Load() {
+		select {
+		case <-shutdown.gracefulDone:
+		case <-time.After(15 * time.Second):
+		}
+	}
 	// clean_stop must be honest: the streamer stopped cleanly only if
 	// it exited without a hard error AND archived all WAL up to the
 	// point a graceful stop's pg_switch_wal fixed. A streamer that
@@ -2033,6 +2089,28 @@ func nextBackoff(cur, max time.Duration) time.Duration {
 // long actually streamed; one that breaks faster is flapping.
 const minHealthyStreamDuration = 5 * time.Second
 
+// serverClosedGrace is the minimum delay before reconnecting after the
+// SERVER ended the COPY (CopyDone). It must be long enough that a
+// demoting primary gets a walsender-free window to finish its
+// fast-shutdown before we reconnect and re-arm one (issue #34).
+const serverClosedGrace = 10 * time.Second
+
+// serverClosedBackoff computes the reconnect delay after a server-
+// initiated CopyDone: an escalating backoff that NEVER resets to the
+// 1s floor and never drops below serverClosedGrace, so repeated
+// re-arms during a slow demote back off increasingly instead of
+// hammering the shutting-down node once per second.
+func serverClosedBackoff(prev, max time.Duration) time.Duration {
+	next := nextBackoff(prev, max)
+	if next < serverClosedGrace {
+		next = serverClosedGrace
+	}
+	if max > 0 && next > max {
+		next = max
+	}
+	return next
+}
+
 // nextStreamBreakBackoff decides the reconnect backoff after a stream
 // attempt that CONNECTED and then broke. A connection that stayed up
 // for at least minHealthyStreamDuration is a real reconnect — reset to
@@ -2059,6 +2137,27 @@ func nextStreamBreakBackoff(streamDuration, prevBackoff, initial, max time.Durat
 // whose remediation requires operator action are listed.  Transient
 // classes (connect.replication, pg.identify_failed) stay on the retry
 // path because a Patroni failover legitimately surfaces as those.
+// checkSysIDContinuity pins the stream's system identifier to the first
+// attempt's value and refuses any later attempt that reports a
+// different one (unless the operator passed --allow-sysid-change). See
+// the retry-loop comment: without this, a reconnect after a DSN
+// repoint to a different cluster interleaves foreign WAL into the
+// deployment's lineage.
+func checkSysIDContinuity(pinned *string, observed, deployment string, allowChange bool) error {
+	if *pinned == "" {
+		*pinned = observed
+		return nil
+	}
+	if observed == *pinned || allowChange {
+		return nil
+	}
+	return output.NewError("wal.system_identifier_changed",
+		fmt.Sprintf("wal stream: system identifier changed across reconnect for %q: streaming began against cluster %s but the connection now reaches cluster %s — refusing to interleave a different cluster's WAL into this deployment's lineage", deployment, *pinned, observed)).
+		WithSuggestion(&output.Suggestion{
+			Human: "the DSN now resolves to a different PostgreSQL cluster (restored clone, re-initialized standby, or a repointed VIP/DNS entry). Point the DSN back at the original cluster, or — if the change is intentional — archive the new cluster under a NEW deployment name (or pass --allow-system-identifier-change after reading the pg_upgrade runbook).",
+		})
+}
+
 func isPermanentStreamSetupError(err error) bool {
 	oe, ok := output.AsOutputError(err)
 	if !ok {
@@ -2459,10 +2558,20 @@ func installSignalCancel(ctx context.Context, cancel context.CancelFunc, shutdow
 		select {
 		case <-sig:
 		case <-ctx.Done():
+			// The stream ended on its own (error, --once). Mark the
+			// graceful path as never-started so nobody waits on it.
+			close(shutdown.gracefulDone)
 			return
 		}
-		// First signal: graceful.
-		go gracefulStopAndCancel(shutdown, cancel)
+		// First signal: graceful. gracefulStarted lets the result
+		// path know it must WAIT for gracefulDone before reading
+		// switchLSN — reading it mid-flight produced a racy, falsely
+		// optimistic clean_stop (concurrency audit).
+		shutdown.gracefulStarted.Store(true)
+		go func() {
+			defer close(shutdown.gracefulDone)
+			gracefulStopAndCancel(shutdown, cancel)
+		}()
 		// Second signal: cancel immediately without waiting for
 		// the flush.  The graceful goroutine above is already
 		// racing to finish; whichever wins, cancel is idempotent.
@@ -2485,6 +2594,13 @@ type walShutdown struct {
 	// stream error). When non-zero it is the bar the streamer's
 	// SyncedLSN must have reached for the stop to count as clean.
 	switchLSN atomic.Uint64
+	// gracefulStarted flips when the first signal launches the
+	// graceful-stop goroutine; gracefulDone closes when that goroutine
+	// (or the no-signal exit path) finishes. The result path waits on
+	// it so clean_stop/switchLSN are read only after pg_switch_wal had
+	// its chance to record the bar — not mid-flight.
+	gracefulStarted atomic.Bool
+	gracefulDone    chan struct{}
 }
 
 // gracefulStopAndCancel implements the signal-driven graceful stop

--- a/internal/cli/wal_server_closed_backoff_test.go
+++ b/internal/cli/wal_server_closed_backoff_test.go
@@ -1,0 +1,40 @@
+package cli
+
+import (
+	"testing"
+	"time"
+)
+
+// Regression (issue #34): after the SERVER ends the COPY (walsender
+// shutting down for a demote), the reconnect delay must NOT drop to the
+// 1s floor — that re-armed a walsender on the still-up demoting primary
+// every second and hung the switchover. It must sit at/above the grace
+// floor and escalate.
+func TestServerClosedBackoff(t *testing.T) {
+	const max = 30 * time.Second
+	// From the 1s floor, a server-closed reconnect jumps to at least
+	// the grace floor (never stays at 1-2s).
+	got := serverClosedBackoff(time.Second, max)
+	if got < serverClosedGrace {
+		t.Errorf("serverClosedBackoff(1s) = %v, want >= grace %v", got, serverClosedGrace)
+	}
+	// Escalates on repeat, capped at max.
+	prev := got
+	for i := 0; i < 6; i++ {
+		next := serverClosedBackoff(prev, max)
+		if next < prev && prev < max {
+			t.Errorf("backoff went backwards: %v -> %v", prev, next)
+		}
+		if next > max {
+			t.Errorf("backoff %v exceeds max %v", next, max)
+		}
+		prev = next
+	}
+	if prev != max {
+		t.Errorf("backoff did not reach max after escalation: %v", prev)
+	}
+	// A low operator max is still respected (never exceeds it).
+	if b := serverClosedBackoff(time.Second, 3*time.Second); b > 3*time.Second {
+		t.Errorf("serverClosedBackoff exceeded low max: %v", b)
+	}
+}

--- a/internal/cli/wal_signal_test.go
+++ b/internal/cli/wal_signal_test.go
@@ -1,0 +1,62 @@
+package cli
+
+import (
+	"context"
+	"syscall"
+	"testing"
+	"time"
+)
+
+// Regression (concurrency audit): the first SIGINT must trigger the
+// GRACEFUL stop path — gracefulStarted flips, the graceful goroutine
+// runs to completion (closing gracefulDone), and only then does the
+// stream ctx cancel. Previously the root signal ctx cancelled the
+// stream first and the handler's select could take the ctx.Done arm,
+// skipping pg_switch_wal entirely.
+func TestInstallSignalCancel_FirstSignalRunsGracefulPath(t *testing.T) {
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+	shutdown := &walShutdown{gracefulDone: make(chan struct{})}
+	// Empty DSN → gracefulStopAndCancel returns immediately after
+	// (deferred) cancel, keeping the test hermetic (no PG needed).
+	installSignalCancel(ctx, cancel, shutdown)
+
+	// Deliver a real SIGINT to ourselves; signal.Notify routes it to
+	// the handler's channel (no default-death while registered).
+	if err := syscall.Kill(syscall.Getpid(), syscall.SIGINT); err != nil {
+		t.Fatalf("self-SIGINT: %v", err)
+	}
+
+	select {
+	case <-shutdown.gracefulDone:
+	case <-time.After(5 * time.Second):
+		t.Fatal("graceful goroutine never completed after first SIGINT")
+	}
+	if !shutdown.gracefulStarted.Load() {
+		t.Error("gracefulStarted not set — the signal took the non-graceful path")
+	}
+	select {
+	case <-ctx.Done():
+	case <-time.After(2 * time.Second):
+		t.Error("stream ctx not cancelled after graceful stop completed")
+	}
+}
+
+// When the stream ends on its own (ctx cancelled without any signal),
+// the handler must close gracefulDone so the result path's wait can
+// never hang, and gracefulStarted must stay false.
+func TestInstallSignalCancel_NoSignalExitClosesDone(t *testing.T) {
+	ctx, cancel := context.WithCancel(context.Background())
+	shutdown := &walShutdown{gracefulDone: make(chan struct{})}
+	installSignalCancel(ctx, cancel, shutdown)
+
+	cancel() // stream ended by itself
+	select {
+	case <-shutdown.gracefulDone:
+	case <-time.After(3 * time.Second):
+		t.Fatal("gracefulDone not closed on the no-signal exit path (result wait would hang)")
+	}
+	if shutdown.gracefulStarted.Load() {
+		t.Error("gracefulStarted set without a signal")
+	}
+}

--- a/internal/pg/streaming/reader.go
+++ b/internal/pg/streaming/reader.go
@@ -313,7 +313,23 @@ func (r *Reader) Receive(ctx context.Context) (pgproto3.BackendMessage, error) {
 			}
 		}
 
+		// Unblock on the CALLER's ctx, not just the constructor ctx:
+		// the watcher goroutine above is bound to the ctx passed at
+		// New() time, so cancelling a per-Receive ctx (the status-tick
+		// failure path stores tickErr and cancels recvCtx expecting an
+		// immediate unblock) did NOT interrupt a Receive parked in
+		// netConn.Read — with a negative InactivityTimeout the stream
+		// hung forever (concurrency audit, demonstrated under -race).
+		// AfterFunc is registered AFTER the deadline set so a cancel
+		// landing between the loop-top ctx check and the set cannot be
+		// missed (an already-cancelled ctx runs the callback
+		// immediately, re-poking the deadline).
+		stopPoke := context.AfterFunc(ctx, func() {
+			_ = r.netConn.SetReadDeadline(time.Unix(1, 0))
+		})
+
 		msg, err := r.frontend.Receive()
+		stopPoke()
 		if err != nil {
 			return nil, r.classifyReadError(ctx, err)
 		}

--- a/internal/pg/streaming/receive_ctx_unblock_test.go
+++ b/internal/pg/streaming/receive_ctx_unblock_test.go
@@ -1,0 +1,63 @@
+package streaming_test
+
+import (
+	"context"
+	"errors"
+	"testing"
+	"time"
+
+	"github.com/cybertec-postgresql/pg_hardstorage/internal/pg/streaming"
+)
+
+// Regression (concurrency audit, demonstrated under -race): cancelling
+// the PER-RECEIVE ctx must unblock a Receive parked in netConn.Read.
+// The deadline-poking watcher is bound to the CONSTRUCTOR ctx, so a
+// per-call recvCtx cancel (the status-tick failure path in
+// replication.runReceiveLoop) previously did nothing — with a negative
+// InactivityTimeout (the --no-inactivity-timeout / wal_sender_timeout=0
+// posture) the stream hung forever: no status updates, restart_lsn
+// frozen, unbounded WAL retention.
+func TestReceive_PerCallCtxCancelUnblocks(t *testing.T) {
+	ctx := context.Background() // constructor ctx: NEVER cancelled
+	// Negative timeout = no read deadline — the exact hang posture.
+	r, _, _ := pipeReader(t, ctx, streaming.Options{InactivityTimeout: -1})
+
+	recvCtx, cancelRecv := context.WithCancel(context.Background())
+	done := make(chan error, 1)
+	go func() {
+		_, err := r.Receive(recvCtx) // parks: the fake server sends nothing
+		done <- err
+	}()
+
+	// Let Receive reach the blocking read, then cancel ONLY recvCtx.
+	time.Sleep(100 * time.Millisecond)
+	cancelRecv()
+
+	select {
+	case err := <-done:
+		if !errors.Is(err, context.Canceled) {
+			t.Errorf("Receive returned %v, want context.Canceled", err)
+		}
+	case <-time.After(3 * time.Second):
+		t.Fatal("Receive still blocked 3s after per-call ctx cancel (pre-fix hang)")
+	}
+}
+
+// The cancel-before-the-deadline-set ordering must not be missable:
+// a ctx cancelled between the loop-top check and the deadline set is
+// caught by AfterFunc's run-immediately semantics.
+func TestReceive_AlreadyCancelledCtxReturnsPromptly(t *testing.T) {
+	r, _, _ := pipeReader(t, context.Background(), streaming.Options{InactivityTimeout: -1})
+	cctx, cancel := context.WithCancel(context.Background())
+	cancel()
+	done := make(chan error, 1)
+	go func() { _, err := r.Receive(cctx); done <- err }()
+	select {
+	case err := <-done:
+		if !errors.Is(err, context.Canceled) {
+			t.Errorf("Receive returned %v, want context.Canceled", err)
+		}
+	case <-time.After(2 * time.Second):
+		t.Fatal("Receive blocked on an already-cancelled ctx")
+	}
+}

--- a/internal/plugin/sink/syslog/reconnect_race_test.go
+++ b/internal/plugin/sink/syslog/reconnect_race_test.go
@@ -1,0 +1,191 @@
+// reconnect_race_test.go — regression test for the close-under-writer
+// and deadline-stomping races in the syslog sink (concurrency audit,
+// bug B).
+//
+// The Dispatcher fans Emits out concurrently with no per-sink
+// serialization. Before the fix, write() snapshotted s.conn under the
+// mutex but called SetWriteDeadline + Write after unlocking, and a
+// failed Emit's dial() unconditionally closed the current connection.
+// Interleaving: Emit-1 sits between deadline-set and Write on conn c1;
+// Emit-2 fails, dials, and closes c1 mid-use — Emit-1 then writes on a
+// closed connection and both events are lost (the dispatcher discards
+// sink errors). Concurrent emits also stomped each other's deadline.
+//
+// This test injects a scripted dialer + fake conns and runs many
+// concurrent Emits under -race. On the old code the fake conn records
+// writes-after-close (and -race flags the unsynchronized accesses);
+// on the fixed code writes are serialized under s.mu and reconnection
+// is generation-aware, so exactly one reconnect happens for the one
+// failed connection generation.
+
+package syslog
+
+import (
+	"context"
+	"errors"
+	"net"
+	"sync"
+	"testing"
+	"time"
+
+	"github.com/cybertec-postgresql/pg_hardstorage/internal/output"
+)
+
+var errInjectedWrite = errors.New("fakeconn: injected write failure")
+
+// fakeConn is an in-memory net.Conn that succeeds the first failAfter
+// writes and fails every write after that (failAfter < 0: never fail).
+// It records Close and counts any Write / SetWriteDeadline attempted
+// after Close — the close-under-writer violation the old code trips.
+type fakeConn struct {
+	failAfter int // number of writes that succeed; <0 = unlimited
+
+	mu         sync.Mutex
+	writes     int // successful writes
+	attempts   int // all writes (successful + injected failures)
+	closed     bool
+	afterClose int // Write/SetWriteDeadline calls observed after Close
+}
+
+func (c *fakeConn) Write(b []byte) (int, error) {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	if c.closed {
+		c.afterClose++
+		return 0, errors.New("fakeconn: write on closed conn")
+	}
+	c.attempts++
+	if c.failAfter >= 0 && c.attempts > c.failAfter {
+		return 0, errInjectedWrite
+	}
+	c.writes++
+	return len(b), nil
+}
+
+func (c *fakeConn) SetWriteDeadline(time.Time) error {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	if c.closed {
+		c.afterClose++
+		return errors.New("fakeconn: deadline on closed conn")
+	}
+	return nil
+}
+
+func (c *fakeConn) Close() error {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	c.closed = true
+	return nil
+}
+
+func (c *fakeConn) Read([]byte) (int, error)        { return 0, errors.New("fakeconn: not readable") }
+func (c *fakeConn) LocalAddr() net.Addr             { return &net.TCPAddr{} }
+func (c *fakeConn) RemoteAddr() net.Addr            { return &net.TCPAddr{} }
+func (c *fakeConn) SetDeadline(time.Time) error     { return nil }
+func (c *fakeConn) SetReadDeadline(time.Time) error { return nil }
+
+func (c *fakeConn) stats() (writes, afterClose int, closed bool) {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	return c.writes, c.afterClose, c.closed
+}
+
+func TestSyslog_ConcurrentEmitReconnectRace(t *testing.T) {
+	const (
+		conn1Successes = 3  // conn #1 fails every write after this many
+		emitters       = 64 // concurrent Emits
+	)
+
+	sink, err := NewFromSpec(output.SinkSpec{Name: "s", Plugin: "syslog", Config: map[string]any{
+		"protocol":     "tcp",
+		"address":      "127.0.0.1:9", // never actually dialed: dialConn seam below
+		"min_severity": "info",
+		"timeout":      "2s",
+	}})
+	if err != nil {
+		t.Fatal(err)
+	}
+	s := sink.(*Sink)
+
+	conn1 := &fakeConn{failAfter: conn1Successes}
+	conn2 := &fakeConn{failAfter: -1} // healthy replacement
+
+	var dialMu sync.Mutex
+	dials := 0
+	s.dialConn = func(context.Context) (net.Conn, error) {
+		dialMu.Lock()
+		defer dialMu.Unlock()
+		dials++
+		if dials == 1 {
+			return conn1, nil
+		}
+		return conn2, nil
+	}
+
+	ctx := context.Background()
+	if err := s.Open(ctx, nil); err != nil {
+		t.Fatal(err)
+	}
+
+	// Fan out concurrent Emits, like the dispatcher does.
+	var wg sync.WaitGroup
+	errs := make([]error, emitters)
+	for i := 0; i < emitters; i++ {
+		wg.Add(1)
+		go func(i int) {
+			defer wg.Done()
+			errs[i] = s.Emit(ctx, output.NewEvent(output.SeverityInfo, "test", "reconnect-race"))
+		}(i)
+	}
+	wg.Wait()
+
+	// Every event must land: failures on conn #1 reconnect and retry
+	// on conn #2 (the dispatcher would silently drop returned errors).
+	for i, err := range errs {
+		if err != nil {
+			t.Fatalf("emit %d: %v", i, err)
+		}
+	}
+
+	w1, after1, closed1 := conn1.stats()
+	w2, after2, closed2 := conn2.stats()
+
+	// (a) No write (or deadline-set) is ever attempted on a closed
+	// conn. The old unlocked write path trips this: a concurrent
+	// dial() closed conn #1 while another Emit was mid-write on it.
+	if after1 != 0 {
+		t.Errorf("conn #1 saw %d write/deadline ops after Close", after1)
+	}
+	if after2 != 0 {
+		t.Errorf("conn #2 saw %d write/deadline ops after Close", after2)
+	}
+
+	// (b) At most one reconnect for the one failed generation: the
+	// initial Open dial plus exactly one redial, no matter how many
+	// concurrent Emits failed on conn #1.
+	if dials != 2 {
+		t.Errorf("dialer called %d times, want 2 (Open + one generation-aware reconnect)", dials)
+	}
+	if !closed1 {
+		t.Error("conn #1 was never closed by the reconnect")
+	}
+	if closed2 {
+		t.Error("conn #2 was closed while the sink is still open")
+	}
+
+	// Accounting: each Emit wrote its frame exactly once.
+	if w1+w2 != emitters {
+		t.Errorf("successful writes: conn1=%d + conn2=%d = %d, want %d", w1, w2, w1+w2, emitters)
+	}
+	if w1 != conn1Successes {
+		t.Errorf("conn #1 successful writes = %d, want %d", w1, conn1Successes)
+	}
+
+	if err := s.Close(); err != nil {
+		t.Fatal(err)
+	}
+	if _, _, closed := conn2.stats(); !closed {
+		t.Error("conn #2 not closed by sink Close")
+	}
+}

--- a/internal/plugin/sink/syslog/syslog.go
+++ b/internal/plugin/sink/syslog/syslog.go
@@ -109,7 +109,12 @@ type Sink struct {
 
 	mu     sync.Mutex
 	conn   net.Conn
+	gen    int // increments on every successful dial; see dial()
 	closed bool
+
+	// dialConn is a test seam: when non-nil it replaces the real
+	// network dial inside dial(). Production code leaves it nil.
+	dialConn func(ctx context.Context) (net.Conn, error)
 }
 
 // NewFromSpec is the SinkBuilder.
@@ -283,41 +288,67 @@ func (s *Sink) Name() string { return s.name }
 // For UDP this is connect-less; for TCP/TLS we dial here and reuse
 // the connection across emits.
 func (s *Sink) Open(ctx context.Context, _ map[string]any) error {
-	return s.dial(ctx)
+	s.mu.Lock()
+	gen := s.gen
+	s.mu.Unlock()
+	return s.dial(ctx, gen)
 }
 
-// dial (re-)establishes the network connection. Caller must hold s.mu.
-func (s *Sink) dial(ctx context.Context) error {
+// dial (re-)establishes the network connection, but only if the
+// connection generation is still failedGen. Emit runs concurrently
+// (the dispatcher fans events out without per-sink serialization), so
+// an unconditional close-and-redial here could yank a connection out
+// from under another Emit that was mid-write, and a burst of failures
+// on one dead connection could trigger a reconnect stampede. The
+// generation counter — incremented on every successful dial — pins
+// each failure to the exact connection it happened on: if s.gen has
+// moved past failedGen, another Emit already reconnected and we
+// simply reuse the fresh connection (concurrency audit, bug B).
+func (s *Sink) dial(ctx context.Context, failedGen int) error {
 	s.mu.Lock()
 	defer s.mu.Unlock()
+	return s.dialLocked(ctx, failedGen)
+}
+
+// dialLocked is dial's body. Caller must hold s.mu.
+func (s *Sink) dialLocked(ctx context.Context, failedGen int) error {
 	if s.closed {
 		return errors.New("syslog: sink closed")
+	}
+	if s.gen != failedGen && s.conn != nil {
+		// Someone else already replaced the failed connection.
+		return nil
 	}
 	if s.conn != nil {
 		_ = s.conn.Close()
 		s.conn = nil
 	}
 
-	dialer := &net.Dialer{Timeout: s.timeout}
 	var conn net.Conn
 	var err error
-	switch s.protocol {
-	case "udp":
-		conn, err = dialer.DialContext(ctx, "udp", s.address)
-	case "tcp":
-		conn, err = dialer.DialContext(ctx, "tcp", s.address)
-	case "tls":
-		// tlsCfg was built eagerly at NewFromSpec time so any
-		// CA / cert misconfiguration fails before Open. Clone
-		// it per-dial — tls.DialWithDialer mutates ServerName
-		// when it doesn't have one, and we want the original
-		// preserved for the next dial attempt.
-		conn, err = tls.DialWithDialer(dialer, "tcp", s.address, s.tlsCfg.Clone())
+	if s.dialConn != nil {
+		conn, err = s.dialConn(ctx)
+	} else {
+		dialer := &net.Dialer{Timeout: s.timeout}
+		switch s.protocol {
+		case "udp":
+			conn, err = dialer.DialContext(ctx, "udp", s.address)
+		case "tcp":
+			conn, err = dialer.DialContext(ctx, "tcp", s.address)
+		case "tls":
+			// tlsCfg was built eagerly at NewFromSpec time so any
+			// CA / cert misconfiguration fails before Open. Clone
+			// it per-dial — tls.DialWithDialer mutates ServerName
+			// when it doesn't have one, and we want the original
+			// preserved for the next dial attempt.
+			conn, err = tls.DialWithDialer(dialer, "tcp", s.address, s.tlsCfg.Clone())
+		}
 	}
 	if err != nil {
 		return fmt.Errorf("syslog: dial %s/%s: %w", s.protocol, s.address, err)
 	}
 	s.conn = conn
+	s.gen++
 	return nil
 }
 
@@ -334,51 +365,55 @@ func (s *Sink) Emit(ctx context.Context, ev *output.Event) error {
 		return err
 	}
 
-	if err := s.write(ctx, frame); err == nil {
+	gen, err := s.write(ctx, frame)
+	if err == nil {
 		return nil
 	}
 
-	// Try a reconnect-and-retry once.
-	if err := s.dial(ctx); err != nil {
+	// Try a reconnect-and-retry once. dial is generation-aware: it
+	// only tears down the connection our write actually failed on; if
+	// a concurrent Emit already reconnected, we retry on its fresh
+	// connection instead of dialing again.
+	if err := s.dial(ctx, gen); err != nil {
 		return err
 	}
-	return s.write(ctx, frame)
+	_, err = s.write(ctx, frame)
+	return err
 }
 
 // write sends the formatted frame on the active conn, dialing if
-// necessary.
-func (s *Sink) write(ctx context.Context, frame []byte) error {
+// necessary. It returns the generation of the connection the write
+// used so a failure can be pinned to exactly that connection (see
+// Emit / dial). The mutex is held across deadline-set + Write —
+// mirroring the CEF sink — so a concurrent Emit can neither stomp
+// our write deadline nor close the connection out from under us.
+func (s *Sink) write(ctx context.Context, frame []byte) (int, error) {
 	// External review pass: SetWriteDeadline reads ctx.Deadline()
 	// but plain ctx.Cancel() (no deadline, just cancellation) was
 	// silently honoured only if we happened to have a deadline.
 	// An explicit ctx.Err() check at the top covers the
 	// cancellation-without-deadline case.
 	if err := ctx.Err(); err != nil {
-		return err
+		return 0, err
 	}
 	s.mu.Lock()
-	conn := s.conn
-	closed := s.closed
-	s.mu.Unlock()
-	if closed {
-		return errors.New("syslog: sink closed")
+	defer s.mu.Unlock()
+	if s.closed {
+		return s.gen, errors.New("syslog: sink closed")
 	}
-	if conn == nil {
-		if err := s.dial(ctx); err != nil {
-			return err
+	if s.conn == nil {
+		if err := s.dialLocked(ctx, s.gen); err != nil {
+			return s.gen, err
 		}
-		s.mu.Lock()
-		conn = s.conn
-		s.mu.Unlock()
 	}
 
 	if deadline, ok := ctx.Deadline(); ok {
-		_ = conn.SetWriteDeadline(deadline)
+		_ = s.conn.SetWriteDeadline(deadline)
 	} else {
-		_ = conn.SetWriteDeadline(time.Now().Add(s.timeout))
+		_ = s.conn.SetWriteDeadline(time.Now().Add(s.timeout))
 	}
-	_, err := conn.Write(frame)
-	return err
+	_, err := s.conn.Write(frame)
+	return s.gen, err
 }
 
 // Close implements output.Sink.

--- a/internal/plugin/storage/scp/scp.go
+++ b/internal/plugin/storage/scp/scp.go
@@ -46,17 +46,21 @@
 //
 // # Atomicity
 //
-// Same model as the sftp backend:
+// Same model as the sftp backend's hardlink path:
 //
-//  1. Stat the destination — if present, return ErrAlreadyExists.
+//  1. Stat the destination — if present, return ErrAlreadyExists
+//     (cheap fast path only; NOT the correctness gate).
 //  2. Write to "<dst>.hstmp-<rand>".
-//  3. mv -T tmp dst (atomic via rename(2) on the same fs).
+//  3. IfNotExists commit: `ln -T tmp dst` — link(2) fails with
+//     EEXIST when dst is present, so exactly one concurrent
+//     writer wins (single-winner consumers — the shared-DEK
+//     object, the backup lease, audit-chain slots — depend on
+//     this). Plain overwrite puts use `mv -T` (rename(2)),
+//     which is last-writer-wins by design.
 //
-// `mv -T` is atomic on every POSIX system when source + dest are
-// on the same filesystem — the standard guarantee for our
-// content-addressed chunk store.  CAS chunks are content-keyed
-// so a duplicate write is harmless; manifest commits use
-// RenameIfNotExists which has the same posture.
+// Both `ln -T` and `mv -T` are atomic on every POSIX system when
+// source + dest are on the same filesystem; manifest commits use
+// RenameIfNotExists, which commits via the same `ln -T`.
 package scp
 
 import (
@@ -108,7 +112,7 @@ func (p *Plugin) Name() string { return "scp" }
 // Capabilities implements storage.StoragePlugin.
 func (p *Plugin) Capabilities() storage.Capabilities {
 	return storage.Capabilities{
-		ConditionalPut: true, // emulated; see top-of-file
+		ConditionalPut: true, // atomic: ln -T (link(2) EEXIST) commits IfNotExists puts
 	}
 }
 
@@ -262,21 +266,32 @@ func (p *Plugin) Put(ctx context.Context, key string, r io.Reader, opts storage.
 	}
 
 	if opts.IfNotExists {
-		// Re-check race window: stat may have raced; if dst
-		// exists, drop the tmp and surface ErrAlreadyExists.
-		if exists, err := p.exists(ctx, full); err != nil {
+		// ATOMIC commit via link(2): `ln -T tmp full` fails with
+		// EEXIST when full is already present, so exactly ONE of
+		// several concurrent writers wins — the loser is told so.
+		//
+		// The previous stat → mv -T pattern was a TOCTOU: rename(2)
+		// silently REPLACES an existing destination, so two writers
+		// that both passed the stat re-check both "succeeded" and the
+		// second overwrote the first. For content-addressed chunks
+		// that is harmless, but for mutable single-key objects that
+		// rely on single-winner semantics — the shared-DEK object
+		// (issue #31's fix), the backup lease, audit-chain event
+		// slots — it silently broke the contract this backend
+		// advertises via ConditionalPut (concurrency audit).
+		if _, lerr := p.runShell(ctx, "ln -T "+shellQuote(tmp)+" "+shellQuote(full)); lerr != nil {
 			_, _ = p.runShell(ctx, "rm -f "+shellQuote(tmp))
-			return storage.PutResult{}, err
-		} else if exists {
-			_, _ = p.runShell(ctx, "rm -f "+shellQuote(tmp))
-			return storage.PutResult{}, storage.ErrAlreadyExists
+			if strings.Contains(lerr.Error(), "File exists") {
+				return storage.PutResult{}, storage.ErrAlreadyExists
+			}
+			return storage.PutResult{}, fmt.Errorf("scp: ln %s -> %s: %w", tmp, full, lerr)
 		}
+		_, _ = p.runShell(ctx, "rm -f "+shellQuote(tmp))
+		return storage.PutResult{Key: key, Size: written}, nil
 	}
 
-	// `mv -T` (rename(2)) is atomic on the same filesystem.
-	// We rely on this for both same-fs writes (the common case
-	// when the repo is one mount) and refuse to operate across
-	// filesystems silently — the rm-of-tmp on error covers it.
+	// `mv -T` (rename(2)) is atomic on the same filesystem — correct
+	// for the last-writer-wins (IfNotExists=false) path only.
 	if _, err := p.runShell(ctx, "mv -T "+shellQuote(tmp)+" "+shellQuote(full)); err != nil {
 		_, _ = p.runShell(ctx, "rm -f "+shellQuote(tmp))
 		return storage.PutResult{}, fmt.Errorf("scp: mv %s -> %s: %w", tmp, full, err)
@@ -433,10 +448,11 @@ func (p *Plugin) Delete(ctx context.Context, key string) error {
 	return nil
 }
 
-// RenameIfNotExists is the manifest-commit primitive.  Uses the
-// same TOCTOU-aware stat-then-rename pattern as the sftp
-// backend; the chunk store's content-addressing absorbs any
-// duplicate writes.
+// RenameIfNotExists is the manifest-commit primitive.  Commits via
+// atomic link(2) (`ln -T` fails EEXIST) + unlink of src, so exactly
+// one concurrent committer wins — the previous stat-then-`mv -T`
+// pattern let a second committer silently replace the first
+// (rename(2) overwrites an existing destination).
 func (p *Plugin) RenameIfNotExists(ctx context.Context, src, dst string) error {
 	if err := p.assertOpen(); err != nil {
 		return err
@@ -449,14 +465,19 @@ func (p *Plugin) RenameIfNotExists(ctx context.Context, src, dst string) error {
 	if err != nil {
 		return err
 	}
+	// Cheap fast path — the atomic gate is the ln below.
 	if exists, err := p.exists(ctx, dstFull); err != nil {
 		return err
 	} else if exists {
 		return storage.ErrAlreadyExists
 	}
-	if _, err := p.runShell(ctx, "mv -T "+shellQuote(srcFull)+" "+shellQuote(dstFull)); err != nil {
-		return fmt.Errorf("scp: mv %s -> %s: %w", srcFull, dstFull, err)
+	if _, lerr := p.runShell(ctx, "ln -T "+shellQuote(srcFull)+" "+shellQuote(dstFull)); lerr != nil {
+		if strings.Contains(lerr.Error(), "File exists") {
+			return storage.ErrAlreadyExists
+		}
+		return fmt.Errorf("scp: ln %s -> %s: %w", srcFull, dstFull, lerr)
 	}
+	_, _ = p.runShell(ctx, "rm -f "+shellQuote(srcFull))
 	return nil
 }
 

--- a/internal/plugin/storage/sftp/sftp.go
+++ b/internal/plugin/storage/sftp/sftp.go
@@ -95,9 +95,21 @@ type Plugin struct {
 func (p *Plugin) Name() string { return "sftp" }
 
 // Capabilities implements storage.StoragePlugin.
+//
+// ConditionalPut is only claimed when the server advertises the
+// hardlink@openssh.com extension — that path maps to POSIX link(2)
+// and is genuinely atomic. The legacy stat-then-rename fallback is
+// NOT (rename overwrites; two concurrent writers can both "win"), so
+// advertising ConditionalPut for it let single-winner consumers
+// (shared-DEK mint, backup lease, audit-chain slots) silently lose
+// writes (concurrency audit).
 func (p *Plugin) Capabilities() storage.Capabilities {
+	cond := true
+	if p.client != nil {
+		_, cond = p.client.HasExtension("hardlink@openssh.com")
+	}
 	return storage.Capabilities{
-		ConditionalPut: true, // emulated; see top-of-file
+		ConditionalPut: cond,
 	}
 }
 

--- a/internal/repo/sharedkey/dishonest_backend_test.go
+++ b/internal/repo/sharedkey/dishonest_backend_test.go
@@ -1,0 +1,86 @@
+package sharedkey_test
+
+import (
+	"bytes"
+	"context"
+	"io"
+	"net/url"
+	"sync"
+	"testing"
+
+	"github.com/cybertec-postgresql/pg_hardstorage/internal/plugin/encryption"
+	"github.com/cybertec-postgresql/pg_hardstorage/internal/plugin/storage"
+	"github.com/cybertec-postgresql/pg_hardstorage/internal/plugin/storage/fs"
+	"github.com/cybertec-postgresql/pg_hardstorage/internal/repo/sharedkey"
+)
+
+// lyingSP wraps a real fs plugin but emulates the OLD scp behaviour:
+// IfNotExists puts are last-writer-wins and NEVER report
+// ErrAlreadyExists — the dishonest-ConditionalPut class from the
+// concurrency audit.
+type lyingSP struct {
+	storage.StoragePlugin
+	mu sync.Mutex
+}
+
+func (l *lyingSP) Put(ctx context.Context, key string, r io.Reader, opts storage.PutOptions) (storage.PutResult, error) {
+	l.mu.Lock()
+	defer l.mu.Unlock() // serialize like a remote fs would; the LIE is dropping IfNotExists
+	body, err := io.ReadAll(r)
+	if err != nil {
+		return storage.PutResult{}, err
+	}
+	opts.IfNotExists = false // the lie: overwrite instead of failing
+	opts.ContentLength = int64(len(body))
+	return l.StoragePlugin.Put(ctx, key, bytes.NewReader(body), opts)
+}
+
+// Regression (concurrency audit): on a backend whose conditional put is
+// dishonest, ResolveOrMint's read-back-adopt must make sequential
+// "winners" converge on the STORED DEK rather than each keeping its own
+// candidate — writer 2's overwrite wins, and writer 1's read-back (which
+// runs after) adopts it; both then agree with a fresh resolve.
+func TestResolveOrMint_ReadBackAdoptsOnDishonestBackend(t *testing.T) {
+	inner := &fs.Plugin{}
+	if err := inner.Open(context.Background(), storage.StorageConfig{
+		URL: &url.URL{Scheme: "file", Path: t.TempDir()},
+	}); err != nil {
+		t.Fatal(err)
+	}
+	defer inner.Close()
+	sp := &lyingSP{StoragePlugin: inner}
+
+	const kekRef = "local:default"
+	kek := testKEK(5)
+	unwrap := unwrapperFor(kek)
+	wrap := wrapperFor(kek)
+
+	// Two mints back-to-back: on the lying backend BOTH puts "succeed".
+	// The read-back must make the final agreed DEK equal what a fresh
+	// resolve sees — no writer keeps a private divergent DEK.
+	r1, err := sharedkey.ResolveOrMint(context.Background(), sp, kekRef, unwrap, wrap)
+	if err != nil || !r1.Have {
+		t.Fatalf("mint 1: %v have=%v", err, r1.Have)
+	}
+	r2, err := sharedkey.ResolveOrMint(context.Background(), sp, kekRef, unwrap, wrap)
+	if err != nil || !r2.Have {
+		t.Fatalf("mint 2: %v have=%v", err, r2.Have)
+	}
+	final, err := sharedkey.ResolveOrMint(context.Background(), sp, kekRef, unwrap, wrap)
+	if err != nil || !final.Have {
+		t.Fatalf("final resolve: %v", err)
+	}
+	if r2.DEK != final.DEK {
+		t.Errorf("writer 2's adopted DEK diverges from the stored DEK")
+	}
+	if r1.DEK != final.DEK {
+		// r1 minted first; the lying backend let r2 overwrite. r1's
+		// read-back ran BEFORE r2's write, so r1 legitimately saw its
+		// own DEK — that residual window is documented. What must
+		// still hold: the STORE is internally consistent (r2+final
+		// agree), and on honest backends (the fixed scp / fs / s3)
+		// r1 == final too. Assert the store-consistency half here.
+		t.Logf("r1 diverges (expected residual on a dishonest backend); store itself is consistent")
+	}
+	_ = encryption.KeyLen
+}

--- a/internal/repo/sharedkey/sharedkey.go
+++ b/internal/repo/sharedkey/sharedkey.go
@@ -211,7 +211,22 @@ func ResolveOrMint(ctx context.Context, sp storage.StoragePlugin, kekRef string,
 	}
 	perr := putSharedDEK(ctx, sp, key, kekRef, wrapped)
 	if perr == nil {
-		return MintResult{DEK: fresh, Have: true}, nil // we minted it
+		// We won the conditional PUT — but do not TRUST it blindly:
+		// read back the stored object and adopt whatever is there. On
+		// honest backends this returns our own wrap (no-op). On a
+		// backend whose IfNotExists emulation is last-writer-wins
+		// (historically scp before its ln-based fix, and sftp servers
+		// without the hardlink extension), two "winners" can both see
+		// perr == nil; adopting the stored content instead of our own
+		// candidate makes writers whose read-back runs after the last
+		// write converge. Defense in depth only — it narrows but
+		// cannot fully close the window; the true guarantee comes
+		// from an atomic ConditionalPut (concurrency audit).
+		stored, ok := readWrappedDEK(ctx, sp, key, kekRef)
+		if !ok {
+			return MintResult{}, fmt.Errorf("sharedkey: shared DEK object unreadable immediately after commit for KEK %q", kekRef)
+		}
+		return unwrapInto(stored, unwrap)
 	}
 	if !errors.Is(perr, storage.ErrAlreadyExists) {
 		return MintResult{}, fmt.Errorf("sharedkey: commit shared DEK: %w", perr)

--- a/internal/restore/postverify/parsemode_alias_test.go
+++ b/internal/restore/postverify/parsemode_alias_test.go
@@ -1,6 +1,9 @@
 package postverify
 
-import "testing"
+import (
+	"strings"
+	"testing"
+)
 
 func TestParseModeAliases(t *testing.T) {
 	for s, want := range map[string]Mode{"skip": ModeOff, "require": ModeRequired, "off": ModeOff, "required": ModeRequired} {
@@ -9,4 +12,32 @@ func TestParseModeAliases(t *testing.T) {
 			t.Errorf("ParseMode(%q)=%v,%v want %v", s, got, err, want)
 		}
 	}
+}
+
+// Regression: the SELECT-1 probe treated psql stderr diagnostics mixed
+// into CombinedOutput (e.g. the collation-version WARNING when a
+// container-built cluster starts on host binaries) as failure even
+// though the query answered. Only the final result row matters.
+func TestProbeOutputAcceptsLeadingDiagnostics(t *testing.T) {
+	ok := []string{
+		"1\n",
+		"WARNING:  database \"postgres\" has a collation version mismatch\nDETAIL:  x\nHINT:  y\n1\n",
+	}
+	for _, out := range ok {
+		lines := splitProbeForTest(out)
+		if len(lines) == 0 || lines[len(lines)-1] != "1" {
+			t.Errorf("output %q rejected; want accepted", out)
+		}
+	}
+	bad := []string{"", "WARNING: x\n", "2\n"}
+	for _, out := range bad {
+		lines := splitProbeForTest(out)
+		if len(lines) > 0 && lines[len(lines)-1] == "1" {
+			t.Errorf("output %q accepted; want rejected", out)
+		}
+	}
+}
+
+func splitProbeForTest(out string) []string {
+	return strings.Fields(strings.TrimSpace(out))
 }

--- a/internal/restore/postverify/postverify.go
+++ b/internal/restore/postverify/postverify.go
@@ -674,7 +674,15 @@ func probeSelect1(ctx context.Context, psql, dsn string) error {
 	if err != nil {
 		return fmt.Errorf("%w (output: %s)", err, truncate(out, 256))
 	}
-	if strings.TrimSpace(string(out)) != "1" {
+	// CombinedOutput interleaves psql's stderr NOTICEs/WARNINGs (e.g.
+	// the collation-version mismatch warning when a cluster built
+	// against one glibc is started on another — routine when restoring
+	// a container-created backup onto a host) with the query result.
+	// The probe's question is only "did the server answer the query?",
+	// so accept any output whose LAST non-empty line is the result row;
+	// diagnostics above it are informational, not failures.
+	lines := strings.Fields(strings.TrimSpace(string(out)))
+	if len(lines) == 0 || lines[len(lines)-1] != "1" {
 		return fmt.Errorf("unexpected output %q", string(out))
 	}
 	return nil

--- a/internal/server/agents.go
+++ b/internal/server/agents.go
@@ -78,10 +78,35 @@ func (r *AgentRegistry) Heartbeat(req HeartbeatRequest) (*Agent, error) {
 	}
 	a.Host = req.Host
 	a.Version = req.Version
-	a.Deployments = append(a.Deployments[:0], req.Deployments...)
+	// Allocate a fresh backing array on every heartbeat instead of
+	// reusing the old one (append(a.Deployments[:0], ...)): snapshots
+	// handed out by Heartbeat/List/Get share the slice header they were
+	// copied from, and rewriting the old array in place raced with
+	// readers iterating those snapshots after the lock was released
+	// (concurrency audit, bug A).
+	a.Deployments = cloneDeployments(req.Deployments)
 	a.LastHeartbeat = now
-	out := *a
+	out := snapshotAgent(a)
 	return &out, nil
+}
+
+// snapshotAgent returns a copy of a that shares no mutable state with
+// the registry-owned record. Caller must hold r.mu (read or write).
+// The Deployments deep copy is defense in depth on top of Heartbeat's
+// fresh-slice allocation: no snapshot ever aliases registry memory.
+func snapshotAgent(a *Agent) Agent {
+	out := *a
+	out.Deployments = cloneDeployments(a.Deployments)
+	return out
+}
+
+// cloneDeployments deep-copies a deployments slice. Empty input maps
+// to nil so the JSON omitempty semantics are preserved.
+func cloneDeployments(d []string) []string {
+	if len(d) == 0 {
+		return nil
+	}
+	return append([]string(nil), d...)
 }
 
 // List returns every registered agent. includeInactive=false omits
@@ -96,7 +121,7 @@ func (r *AgentRegistry) List(includeInactive bool) []Agent {
 		if !includeInactive && !a.IsActive(r.timeout, now) {
 			continue
 		}
-		out = append(out, *a)
+		out = append(out, snapshotAgent(a))
 	}
 	sort.Slice(out, func(i, j int) bool { return out[i].ID < out[j].ID })
 	return out
@@ -110,7 +135,7 @@ func (r *AgentRegistry) Get(id string) *Agent {
 	if !ok {
 		return nil
 	}
-	out := *a
+	out := snapshotAgent(a)
 	return &out
 }
 

--- a/internal/server/agents_race_test.go
+++ b/internal/server/agents_race_test.go
@@ -1,0 +1,158 @@
+// agents_race_test.go — regression tests for the AgentRegistry
+// heartbeat slice race (concurrency audit, bug A).
+//
+// Before the fix, Heartbeat reused the Deployments backing array
+// (append(a.Deployments[:0], ...)) while every snapshot (Heartbeat's
+// returned copy, List, Get) copied the struct shallowly. Readers
+// iterating a snapshot's Deployments after the registry lock was
+// released raced with the next heartbeat rewriting the same backing
+// array in place. TestAgentRegistry_HeartbeatSnapshotRace reproduces
+// exactly that interleaving and fails under `go test -race` on the
+// old code.
+
+package server_test
+
+import (
+	"sync"
+	"testing"
+	"time"
+
+	"github.com/cybertec-postgresql/pg_hardstorage/internal/server"
+)
+
+// TestAgentRegistry_HeartbeatSnapshotRace hammers Heartbeat for one
+// agent with varying deployment lists while reader goroutines iterate
+// the Deployments of List/Get snapshots outside the registry lock.
+func TestAgentRegistry_HeartbeatSnapshotRace(t *testing.T) {
+	reg := server.NewAgentRegistry(time.Minute)
+
+	// Varying lengths, all <= the first list's length, so the old
+	// append(a.Deployments[:0], ...) reused (and rewrote) the same
+	// backing array on every heartbeat.
+	lists := [][]string{
+		{"deploy-alpha", "deploy-beta", "deploy-gamma"},
+		{"deploy-delta", "deploy-epsilon"},
+		{"deploy-zeta"},
+		{"deploy-eta", "deploy-theta", "deploy-iota"},
+	}
+
+	const (
+		iterations = 400
+		readers    = 4
+	)
+
+	var wg sync.WaitGroup
+	done := make(chan struct{})
+
+	// Writer: re-heartbeat the same agent with rotating lists.
+	wg.Add(1)
+	go func() {
+		defer wg.Done()
+		defer close(done)
+		for i := 0; i < iterations; i++ {
+			out, err := reg.Heartbeat(server.HeartbeatRequest{
+				ID:          "agent-1",
+				Host:        "host-1",
+				Version:     "v1",
+				Deployments: lists[i%len(lists)],
+			})
+			if err != nil {
+				t.Errorf("Heartbeat: %v", err)
+				return
+			}
+			// Read the returned snapshot outside the lock, like the
+			// heartbeat HTTP handler does when it marshals it.
+			consumeDeployments(out.Deployments)
+		}
+	}()
+
+	// Readers: snapshot via List/Get, then iterate the strings after
+	// the registry lock has been released (like handleAgents' JSON
+	// marshal and refreshScrapeGauges).
+	for r := 0; r < readers; r++ {
+		wg.Add(1)
+		go func() {
+			defer wg.Done()
+			for {
+				select {
+				case <-done:
+					return
+				default:
+				}
+				for _, a := range reg.List(true) {
+					consumeDeployments(a.Deployments)
+				}
+				if a := reg.Get("agent-1"); a != nil {
+					consumeDeployments(a.Deployments)
+				}
+			}
+		}()
+	}
+
+	wg.Wait()
+}
+
+// consumeDeployments reads every string element so the race detector
+// observes the access to the slice's backing array.
+func consumeDeployments(d []string) int {
+	total := 0
+	for _, s := range d {
+		total += len(s)
+	}
+	return total
+}
+
+// TestAgentRegistry_SnapshotImmutable asserts the semantic contract:
+// a snapshot taken from Heartbeat, Get, or List must not change when
+// a later heartbeat replaces the agent's deployments.
+func TestAgentRegistry_SnapshotImmutable(t *testing.T) {
+	reg := server.NewAgentRegistry(time.Minute)
+
+	first := []string{"deploy-a", "deploy-b"}
+	hbSnap, err := reg.Heartbeat(server.HeartbeatRequest{
+		ID: "agent-1", Host: "host-1", Deployments: first,
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	getSnap := reg.Get("agent-1")
+	if getSnap == nil {
+		t.Fatal("Get returned nil for a registered agent")
+	}
+	listSnap := reg.List(true)
+	if len(listSnap) != 1 {
+		t.Fatalf("List returned %d agents, want 1", len(listSnap))
+	}
+
+	// Overwrite with a different (shorter, then longer) list; the old
+	// code rewrote the snapshots' shared backing array in place.
+	for _, next := range [][]string{{"deploy-x"}, {"deploy-y", "deploy-z", "deploy-w"}} {
+		if _, err := reg.Heartbeat(server.HeartbeatRequest{
+			ID: "agent-1", Host: "host-1", Deployments: next,
+		}); err != nil {
+			t.Fatal(err)
+		}
+	}
+
+	for name, got := range map[string][]string{
+		"Heartbeat snapshot": hbSnap.Deployments,
+		"Get snapshot":       getSnap.Deployments,
+		"List snapshot":      listSnap[0].Deployments,
+	} {
+		if len(got) != len(first) {
+			t.Fatalf("%s changed length after later heartbeats: got %v, want %v", name, got, first)
+		}
+		for i := range first {
+			if got[i] != first[i] {
+				t.Errorf("%s mutated by a later heartbeat: got %v, want %v", name, got, first)
+				break
+			}
+		}
+	}
+
+	// The live record must reflect the latest heartbeat, of course.
+	cur := reg.Get("agent-1")
+	if cur == nil || len(cur.Deployments) != 3 || cur.Deployments[0] != "deploy-y" {
+		t.Errorf("current record wrong after heartbeats: %+v", cur)
+	}
+}

--- a/internal/wal/follower/coordinator.go
+++ b/internal/wal/follower/coordinator.go
@@ -56,6 +56,12 @@ import (
 const (
 	gapPersistAttempts = 4
 	gapPersistBackoff  = 250 * time.Millisecond
+	// gapPersistFinalTimeout bounds the ONE extra Put attempt made on a
+	// detached context when the caller's ctx is cancelled mid-persist
+	// (agent shutdown racing failover handling). Short on purpose: it
+	// delays shutdown only when storage is slow, and a healthy repo
+	// answers well within it.
+	gapPersistFinalTimeout = 5 * time.Second
 )
 
 // SlotRole names which Patroni cluster member a SlotSpec is
@@ -571,10 +577,11 @@ func (c *Coordinator) reconcileOneSlot(ctx context.Context, dsn string, endpoint
 }
 
 // persistGap writes a gapstate.Record for the just-detected
-// gap. Best-effort: failures emit a warning event but don't
-// propagate. The same wal_gap_detected event already fired
-// before this call, so the operator's alerting pipeline has
-// the signal regardless.
+// gap. Failures don't propagate, but they are NOT silent: every
+// exit path that leaves the record unpersisted emits a CRITICAL
+// gap_persist_failed event. The same wal_gap_detected event
+// already fired before this call, so the operator's alerting
+// pipeline has the detection signal regardless.
 func (c *Coordinator) persistGap(ctx context.Context, endpoint patroni.LeaderEndpoint, slot SlotSpec, cont *replication.SlotContinuityResult) {
 	if c.opts.GapStore == nil {
 		return // store not wired (tests, library-only callers)
@@ -603,6 +610,11 @@ func (c *Coordinator) persistGap(ctx context.Context, endpoint patroni.LeaderEnd
 		if attempt > 0 {
 			select {
 			case <-ctx.Done():
+				// Shutdown raced the retry loop. Bailing out here would
+				// silently drop the once-only record, so make ONE final
+				// attempt on a short context detached from the cancelled
+				// ctx — when storage is healthy the record still lands.
+				c.persistGapFinal(ctx, endpoint, slot, rec, lastErr)
 				return
 			case <-time.After(gapPersistBackoff * time.Duration(attempt)):
 			}
@@ -612,7 +624,45 @@ func (c *Coordinator) persistGap(ctx context.Context, endpoint patroni.LeaderEnd
 			return // persisted (already-exists ⇒ a prior attempt's write landed)
 		}
 		lastErr = err
+		if ctx.Err() != nil {
+			// The attempt itself failed under an already-cancelled ctx —
+			// a ctx-aware store fails every further retry the same way,
+			// including the very FIRST attempt when shutdown races the
+			// failover handling. Same detached final attempt as the
+			// backoff-select path above.
+			c.persistGapFinal(ctx, endpoint, slot, rec, lastErr)
+			return
+		}
 	}
+	c.emitGapPersistFailed(endpoint, slot, rec, lastErr)
+}
+
+// persistGapFinal is persistGap's shutdown path: the retry loop's ctx was
+// cancelled while the record was still unpersisted. A WAL gap is detected
+// exactly once — at slot recreation — so agent shutdown must not lose the
+// record when storage is actually healthy. Make ONE final Put attempt on a
+// short context detached from the cancelled ctx (values retained,
+// cancellation dropped); if even that fails, the record really is lost and
+// we escalate CRITICAL exactly like the exhausted-retries path.
+func (c *Coordinator) persistGapFinal(ctx context.Context, endpoint patroni.LeaderEndpoint, slot SlotSpec, rec gapstate.Record, lastErr error) {
+	fctx, cancel := context.WithTimeout(context.WithoutCancel(ctx), gapPersistFinalTimeout)
+	defer cancel()
+	_, err := c.opts.GapStore.Put(fctx, rec)
+	if err == nil || errors.Is(err, storage.ErrAlreadyExists) {
+		return // persisted (already-exists ⇒ a prior attempt's write landed)
+	}
+	if lastErr != nil {
+		err = fmt.Errorf("final attempt on detached context: %w (last error before shutdown: %v)", err, lastErr)
+	}
+	// emit is synchronous and does not consult any context, so the
+	// CRITICAL escalation is delivered even though ctx is cancelled.
+	c.emitGapPersistFailed(endpoint, slot, rec, err)
+}
+
+// emitGapPersistFailed emits the CRITICAL escalation for a gap record that
+// could not be persisted. Fired on BOTH unpersisted exit paths — retries
+// exhausted, and shutdown with the detached final attempt also failing.
+func (c *Coordinator) emitGapPersistFailed(endpoint patroni.LeaderEndpoint, slot SlotSpec, rec gapstate.Record, lastErr error) {
 	c.emit(output.NewEvent(output.SeverityCritical, "wal.follower", "gap_persist_failed").
 		WithSubject(output.Subject{Deployment: c.opts.Deployment}).
 		WithBody(map[string]any{

--- a/internal/wal/follower/persistgap_shutdown_test.go
+++ b/internal/wal/follower/persistgap_shutdown_test.go
@@ -1,0 +1,168 @@
+package follower_test
+
+import (
+	"context"
+	"errors"
+	"io"
+	"sync"
+	"testing"
+	"time"
+
+	"github.com/cybertec-postgresql/pg_hardstorage/internal/output"
+	"github.com/cybertec-postgresql/pg_hardstorage/internal/patroni"
+	"github.com/cybertec-postgresql/pg_hardstorage/internal/plugin/storage"
+	"github.com/cybertec-postgresql/pg_hardstorage/internal/wal/follower"
+	"github.com/cybertec-postgresql/pg_hardstorage/internal/wal/gapstate"
+)
+
+// These tests pin the shutdown behaviour of persistGap: a WAL gap is
+// detected exactly once (at slot recreation), so agent shutdown (ctx
+// cancellation) racing failover handling must NOT silently drop the
+// record. The old code's retry loop had `case <-ctx.Done(): return`,
+// which lost the record without persisting it AND without emitting the
+// CRITICAL gap_persist_failed escalation — permanently disarming restore
+// preflight's refusal of PITR targets inside the gap.
+
+// newGapCoordinator wires a Coordinator whose reconcile seam always
+// reports the canonical 420-byte gap, persisting into gs.
+func newGapCoordinator(t *testing.T, gs *gapstate.Store, rec *recordingSink) *follower.Coordinator {
+	t.Helper()
+	coord, err := follower.New(follower.Options{
+		Client:                 fakePatroniClient(t),
+		SlotName:               "slot1",
+		Deployment:             "db1",
+		DSNFor:                 func(string, int) string { return "postgres://x" },
+		TimelineStore:          newTimelineStore(t),
+		GapStore:               gs,
+		OnEvent:                rec.record,
+		ReconcileSlot:          gapReconcile(),
+		CaptureTimelineHistory: func(context.Context, string, uint32) error { return nil },
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	return coord
+}
+
+func fireGapLeaderChange(ctx context.Context, coord *follower.Coordinator) {
+	coord.HandleLeaderChange(ctx, patroni.LeaderChange{
+		New: &patroni.LeaderEndpoint{Name: "node-2", Host: "h2", Port: 5432, Timeline: 7, Role: "leader"},
+	})
+}
+
+// TestPersistGap_ShutdownPersistsViaDetachedContext: ctx is ALREADY
+// cancelled when the gap is detected, but the store itself is healthy
+// (the fs plugin fails a Put only because it is ctx-aware). The record
+// must still land via the one final Put on a detached context, and no
+// gap_persist_failed escalation fires.
+func TestPersistGap_ShutdownPersistsViaDetachedContext(t *testing.T) {
+	rec := &recordingSink{}
+	gs := gapstate.New(newGapStoreSP(t)) // healthy, ctx-aware fs store
+	coord := newGapCoordinator(t, gs, rec)
+
+	ctx, cancel := context.WithCancel(context.Background())
+	cancel() // shutdown already in progress before the failover is handled
+	fireGapLeaderChange(ctx, coord)
+
+	got, err := gs.List(context.Background(), "db1")
+	if err != nil {
+		t.Fatalf("List gaps: %v", err)
+	}
+	if len(got) != 1 {
+		t.Fatalf("len(gaps) = %d, want 1 (detached final attempt must persist the once-only record)", len(got))
+	}
+	if got[0].GapBytes != 420 {
+		t.Errorf("GapBytes = %d, want 420", got[0].GapBytes)
+	}
+	if ev := rec.firstWithOp("gap_persist_failed"); ev != nil {
+		t.Errorf("gap_persist_failed must not fire when the detached attempt succeeds; got %+v", ev)
+	}
+}
+
+// TestPersistGap_ShutdownStoreDownEscalatesCritical: ctx is cancelled AND
+// the store fails even on the detached final attempt. The record is
+// genuinely lost, so the CRITICAL gap_persist_failed event MUST be
+// emitted — silence here is the original bug.
+func TestPersistGap_ShutdownStoreDownEscalatesCritical(t *testing.T) {
+	rec := &recordingSink{}
+	// flakyPutSP fails before delegating, regardless of ctx — so the
+	// detached attempt fails too.
+	flaky := &flakyPutSP{StoragePlugin: newGapStoreSP(t), failsLeft: 100}
+	gs := gapstate.New(flaky)
+	coord := newGapCoordinator(t, gs, rec)
+
+	ctx, cancel := context.WithCancel(context.Background())
+	cancel()
+	fireGapLeaderChange(ctx, coord)
+
+	got, _ := gs.List(context.Background(), "db1")
+	if len(got) != 0 {
+		t.Errorf("no record should persist when the store is down; got %d", len(got))
+	}
+	ev := rec.firstWithOp("gap_persist_failed")
+	if ev == nil {
+		t.Fatal("expected gap_persist_failed on shutdown with a failing store (old code exited silently)")
+	}
+	if ev.Op != "gap_persist_failed" {
+		t.Errorf("Op = %q, want gap_persist_failed", ev.Op)
+	}
+	if ev.Severity != output.SeverityCritical {
+		t.Errorf("severity = %v, want SeverityCritical (operator must record the gap by hand)", ev.Severity)
+	}
+}
+
+// cancelAfterFirstPutSP fails the FIRST Put transiently (without
+// consulting ctx) and schedules the shutdown cancel shortly after, so the
+// retry loop's backoff select observes ctx.Done mid-retry. Subsequent
+// Puts delegate to the (ctx-aware) wrapped plugin.
+type cancelAfterFirstPutSP struct {
+	storage.StoragePlugin
+	cancel context.CancelFunc
+
+	mu   sync.Mutex
+	puts int
+}
+
+func (f *cancelAfterFirstPutSP) Put(ctx context.Context, key string, r io.Reader, opts storage.PutOptions) (storage.PutResult, error) {
+	f.mu.Lock()
+	f.puts++
+	first := f.puts == 1
+	f.mu.Unlock()
+	if first {
+		// Transient failure; shutdown begins moments later, while the
+		// retry loop sits in its backoff sleep.
+		time.AfterFunc(30*time.Millisecond, f.cancel)
+		return storage.PutResult{}, errors.New("injected transient put failure")
+	}
+	return f.StoragePlugin.Put(ctx, key, r, opts)
+}
+
+// TestPersistGap_CancelMidRetryPersistsViaDetachedContext pins the exact
+// original bug shape: the first Put fails transiently, then shutdown
+// cancels ctx while the loop is backing off. The old `case <-ctx.Done():
+// return` dropped the record; the fix's detached final attempt must
+// persist it (the store is healthy by then).
+func TestPersistGap_CancelMidRetryPersistsViaDetachedContext(t *testing.T) {
+	rec := &recordingSink{}
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+	sp := &cancelAfterFirstPutSP{StoragePlugin: newGapStoreSP(t), cancel: cancel}
+	gs := gapstate.New(sp)
+	coord := newGapCoordinator(t, gs, rec)
+
+	fireGapLeaderChange(ctx, coord)
+
+	if err := ctx.Err(); err == nil {
+		t.Fatal("test harness bug: ctx should have been cancelled during the retry loop")
+	}
+	got, err := gs.List(context.Background(), "db1")
+	if err != nil {
+		t.Fatalf("List gaps: %v", err)
+	}
+	if len(got) != 1 {
+		t.Fatalf("len(gaps) = %d, want 1 (cancel mid-retry must not lose the record)", len(got))
+	}
+	if ev := rec.firstWithOp("gap_persist_failed"); ev != nil {
+		t.Errorf("gap_persist_failed must not fire when the detached attempt succeeds; got %+v", ev)
+	}
+}


### PR DESCRIPTION
A three-way concurrency review (WAL pipeline · backup/CAS/storage · daemons/audit) found **10 distinct concurrency bugs**, three demonstrated under `-race`. Each fix ships with a regression test. The review also surfaced the root cause of **issue #34** (Patroni switchover hang), fixed here too, plus a restore-postverify false failure caught during E2E.

## Bugs & fixes

| Bug | Severity | Fix | Test |
|-----|----------|-----|------|
| **Lease stale-reclaim race** — two reclaimers both hold the same deployment lease (unconditional `Delete` destroys a fresh reclaim) | mutual-exclusion broken | recheck → overwrite-in-place → settle-verify; never deletes | `-race` ✅ |
| **`Renew` clobbers a reclaimer** — stalled holder overwrites a legit reclaim | wrong-result | settle margin before write + post-write settle-verify → `ErrLeaseLost` | ✅ |
| **Runner ignored lease loss** — only logged; both backups ran | wrong-result | `context.WithCancelCause`: loss aborts, transient stays warning | ✅ |
| **scp/sftp fake `IfNotExists`** — `mv -T` overwrites → forked shared DEK (#31 class) **and** destroyed committed audit events | **data-loss** | atomic `ln -T` (link(2) EEXIST); sftp claims ConditionalPut only with hardlink ext; sharedkey read-back-adopt | ✅ |
| **First SIGINT killed graceful WAL stop** — drain never ran; false `clean_stop` | wrong-result | stream ctx `WithoutCancel(root)`; single signal authority; wait for graceful goroutine | ✅ |
| **`wal stream` hangs forever** on a status-tick send failure (quiet stream) | **hang** | `Receive` unblocks on the per-call ctx via `AfterFunc` | `-race` ✅ |
| **Sysid guard skipped on reconnect** — failover to a different cluster interleaves foreign WAL | **data-loss** | recheck sysid every attempt; permanent refusal on change | ✅ |
| **WAL-gap record dropped on shutdown** — silent, no CRITICAL | wrong-result | detached-ctx final Put + emit on every unpersisted exit | ✅ |
| **AgentRegistry slice race** — heartbeat rewrites a backing array shared with `/v1/agents` marshals | Go data race | deep-copy at every snapshot boundary | `-race` ✅ |
| **Syslog sink close-under-writer** — reconnect closes a conn another emit uses; deadline stomping | data-loss | write under `mu`; generation-aware reconnect | ✅ |

## Issue #34 — Patroni switchover hang
A server-initiated `CopyDone` (walsender shutting down to demote) reset the reconnect backoff to the **1 s floor**, so we reconnected to the still-up, still-read-write demoting primary (`target_session_attrs=primary` matches it until `pg_ctl stop` finishes) and re-armed a walsender that **blocked the very fast-shutdown in progress** — the demote hung until the service was restarted. Server-closed streams now reconnect with an escalating grace delay (≥ 10 s), giving the node walsender-free windows to finish the demote, after which the reconnect routes to the new primary.

**Validation caveat:** the fix is traced from the code path and the backoff behavior is unit-tested, but I could not reproduce a live 3-node Patroni switchover in this environment. @chrnoe — please confirm against a build from this branch; happy to iterate if the hang persists.

## Bonus (found in E2E)
`restore --verify` postverify rejected psql stderr diagnostics (e.g. the collation-version `WARNING` when a container-built cluster starts on host binaries) mixed into `CombinedOutput`; the `SELECT 1` probe now checks only the final result row.

## Verification
- `-race` gate on every touched package + full-breadth suite: **green**; `go vet` clean.
- E2E: encrypted repo + `wal stream` + racing concurrent backups (one correctly refused by the lease) + single-SIGINT graceful stop (honest `clean_stop: true`) → all backups verify + restore, exactly one shared-DEK object.
