### PR TITLE
integrity: scheduled drills, mandatory contract concurrency, chaos soak

### DIFF
--- a/.github/workflows/chaos-soak.yml
+++ b/.github/workflows/chaos-soak.yml
@@ -1,0 +1,60 @@
+# chaos-soak.yml — nightly randomized chaos soak with a restore-proof
+# gate (integrity program #1; see docs/operations/integrity-testing.md).
+#
+# Runs the production model — encrypted repo, continuous `wal stream`,
+# concurrent backups, constant churn — over a real 3-node Patroni
+# cluster while injecting a seeded random fault schedule (switchovers,
+# leader pauses, concurrent-backup bursts). Pass criterion is never
+# "exit 0": every committed backup must verify --full AND restore, the
+# WAL lineage must be gap-free, and exactly one shared-DEK object may
+# exist. This is the harness class that would have caught #31 and #34
+# before users did.
+#
+# A failure log always includes the seed; re-run the identical fault
+# schedule with:  workflow_dispatch → seed=<seed>.
+name: chaos-soak
+
+on:
+  schedule:
+    - cron: "17 3 * * *" # nightly, 03:17 UTC
+  workflow_dispatch:
+    inputs:
+      minutes:
+        description: "Soak budget in minutes"
+        default: "45"
+      seed:
+        description: "Fault-schedule seed (empty = random)"
+        default: ""
+
+permissions:
+  contents: read
+
+env:
+  GO_VERSION: "1.26.4"
+
+jobs:
+  chaos-soak:
+    name: chaos soak (restore-proof gate)
+    runs-on: ubuntu-24.04
+    timeout-minutes: 120
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-go@v5
+        with:
+          go-version: ${{ env.GO_VERSION }}
+          cache: true
+      - name: Build the binary under test
+        run: go build -o /tmp/pghs-chaos ./cmd/pg_hardstorage
+      - name: Pre-pull cluster images
+        run: |
+          docker pull -q ghcr.io/zalando/spilo-17:4.0-p1
+          docker pull -q quay.io/coreos/etcd:v3.5.13
+      - name: Run the soak
+        env:
+          PGHS_CHAOS_BIN: /tmp/pghs-chaos
+          PGHS_CHAOS_MINUTES: ${{ github.event.inputs.minutes || '45' }}
+          PGHS_CHAOS_SEED: ${{ github.event.inputs.seed || '' }}
+        run: |
+          go test -count=1 -timeout 110m -v \
+            -run TestChaosSoak_RestoreProof \
+            ./internal/testkit/topology/

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -338,6 +338,37 @@ jobs:
           cache: true
       - run: go test -race -count=1 -timeout=10m ./...
 
+  # Storage-backend CONTRACT gate against REAL servers — the
+  # zero-tolerated-failures policy (integrity program #2). The suite
+  # includes the mandatory ParallelPuts single-winner case: a backend
+  # that claims ConditionalPut and loses it is the scp `mv -T` class of
+  # data-loss bug (forked shared DEK, silently destroyed audit events).
+  # The DEMAND vars turn "server unavailable → skip" into a hard
+  # failure, so this gate can never silently stop testing.
+  storage-contract:
+    name: storage contract (real sftp/scp servers)
+    runs-on: ubuntu-24.04
+    needs: [vet]
+    timeout-minutes: 15
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-go@v5
+        with:
+          go-version: ${{ env.GO_VERSION }}
+          cache: true
+      - name: Ensure sshd is installed (scp contract fixture)
+        run: sudo apt-get update -qq && sudo apt-get install -y -qq openssh-server
+      - name: Contract suites (docker sftp + host-sshd scp; skips forbidden)
+        env:
+          PG_HARDSTORAGE_DEMAND_DOCKER: "1"
+          PG_HARDSTORAGE_DEMAND_SSHD: "1"
+        run: |
+          go test -race -count=1 -timeout=12m \
+            ./internal/plugin/storage/sftp/ \
+            ./internal/plugin/storage/scp/ \
+            ./internal/plugin/storage/fs/ \
+            ./internal/plugin/storage/contract/
+
   restore-correctness:
     # L6 of the restore-correctness defence stack — a fast
     # per-PR end-to-end gate that exercises the full

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,59 @@ keeps reading that version for at least 24 months after a successor lands.
 
 ## [Unreleased]
 
+### Integrity program: scheduled drills, contract enforcement, chaos soak
+
+Three layers landed to keep "backup that won't restore" in the class of
+bugs machines catch first (see the new
+[Integrity testing](https://pghardstorage.org/operations/integrity-testing/)
+page):
+
+- **Scheduled recovery drills.** Deployments can now declare a
+  `schedule.drill` alongside `backup` and `rotate`
+  (`pg_hardstorage schedule db1 'daily_at 03:00' --task drill`); the
+  agent restores the latest backup into a scratch dir and verifies it on
+  that cadence, recording every verdict in the repo's drill history.
+  `doctor` gained drill-freshness checks — `recovery.drill_never_run`
+  (notice), `recovery.drill_failing` (critical), and
+  `recovery.drill_stale` (critical, tunable via `--drill-max-age`,
+  default 7d) — plus a `drills` report section for dashboards.
+- **Storage-contract concurrency cases are now mandatory.** Every
+  backend runs `ParallelPuts_SingleWinner` and
+  `ParallelOverwrites_NoTornContent`; a backend claiming
+  `ConditionalPut: true` that loses the race is red, while an honest
+  `false` skips and its callers degrade loudly instead: the backup
+  runner emits a `lease_unenforceable` warning event and the audit
+  chain read-back-verifies every slot it wins. The scp backend is now
+  contract-tested against a real `sshd`, which surfaced (and fixed) a
+  session-open retry needed under `MaxSessions` backpressure. A
+  dedicated CI job runs these with the `DEMAND` env vars so the fixtures
+  can never silently skip.
+- **Nightly chaos soak with a restore-proof gate.** A seeded random
+  fault loop (Patroni switchovers, leader pauses, concurrent-backup
+  bursts) over a real 3-node cluster with an encrypted repo and a
+  continuous — never restarted — `wal stream`. Pass requires every
+  committed backup to `verify --full` AND restore, a gap-free
+  `wal audit`, and exactly one shared-DEK object; the seed is logged so
+  any failure replays deterministically.
+
+The very first soak run caught a real bug, now fixed: **`verify --full`
+(and the agent's scheduled verify) ran the wrong-major sandbox for every
+backup.** Manifests store the plain PostgreSQL major (`pg_version: 17`),
+but the sandbox-major helper expected `server_version_num` form and
+divided by 10000 — every backup fell back to the PG18 default sandbox,
+whose `pg_verifybackup` rejects a PG17 `pg_control` with "CRC is
+incorrect". Healthy, fully-restorable backups were reported as
+corrupt. The helper now recognises plain majors; the failure path also
+gained the actual pg_verifybackup output in its error message (it
+previously pointed at a `tool_stdout` body field that error results
+don't carry, and dropped stderr — where pg_verifybackup writes its
+findings — entirely).
+
+Also fixed while validating: agent-scheduled drills against an
+encrypted repo failed instantly because the drill task did not wire the
+keystore KEK resolver the way the `recovery drill` CLI does — it now
+does.
+
 ## [1.0.15] — 2026-07-23
 
 ### Fix: Patroni switchover hang — the real cause (#34, supersedes 1.0.14)

--- a/docs/how-to/operating/schedule-backups.md
+++ b/docs/how-to/operating/schedule-backups.md
@@ -6,13 +6,15 @@ tags:
   - schedule
   - backup
   - rotate
+  - drill
 ---
 
 # Schedule backups
 
-> Each deployment declares a `backup` and a `rotate` schedule.
-> The agent runs both at the configured cadence; the
-> `pg_hardstorage schedule` subcommand reads and writes them.
+> Each deployment declares a `backup`, a `rotate`, and
+> (optionally) a `drill` schedule. The agent runs them at the
+> configured cadence; the `pg_hardstorage schedule` subcommand
+> reads and writes them.
 
 ## What you need
 
@@ -55,10 +57,13 @@ Schedules for 3 deployment(s):
   DEPLOYMENT  TASK    WHEN
   db1         backup  every 6h0m0s
   db1         rotate  daily at 04:00 (Local)
+  db1         drill   daily at 03:00 (Local)
   db2         backup  daily at 02:00 (Local)
   db2         rotate  daily at 03:30 (Local)
+  db2         drill   off
   db3         backup  off
   db3         rotate  off
+  db3         drill   off
 ```
 
 The fleet listing surfaces both tasks — useful for spotting
@@ -104,7 +109,21 @@ Convention: rotate **after** the typical backup window so a
 just-completed backup doesn't get classified as a candidate by
 a sweep that started before it committed.
 
-### 5. Clear a schedule
+### 5. Set the drill schedule
+
+```bash
+pg_hardstorage schedule db1 'daily_at 03:00' --task=drill
+```
+
+A scheduled drill restores the latest backup into a scratch
+directory and verifies it — the continuous proof that the
+backup you just took actually restores. Convention: drill
+**after** the backup window (backup at 02:00 → drill at 03:00)
+so each drill proves the freshest backup. `doctor` alarms when
+drills are missing, failing, or stale — see
+[Integrity testing](../../operations/integrity-testing.md).
+
+### 6. Clear a schedule
 
 ```bash
 pg_hardstorage schedule db1 off
@@ -124,10 +143,13 @@ deployments:
     schedule:
       backup: { every: "6h" }
       rotate: { daily_at: "04:00" }
+      drill:  { daily_at: "03:00" }
 ```
 
 Three keys per task: `every:`, `daily_at:`, or `at:`. Setting
-more than one is a config error.
+more than one is a config error. `drill:` is optional — but a
+deployment without it never proves restorability, and `doctor`
+raises `recovery.drill_never_run`.
 
 ## Coordination across deployments
 
@@ -192,4 +214,6 @@ when the box can handle the parallelism.
   schedule
 - [Verify backups](verify-fast-vs-full.md) — schedule periodic
   verification
+- [Integrity testing](../../operations/integrity-testing.md) —
+  scheduled drills, doctor freshness, and the chaos soak
 - [`schedule` CLI reference](../../reference/cli/pg_hardstorage_schedule.md)

--- a/docs/operations/integrity-testing.md
+++ b/docs/operations/integrity-testing.md
@@ -1,0 +1,217 @@
+---
+title: Integrity testing
+description: The three-layer program that proves backups restore —
+              scheduled recovery drills with doctor freshness alarms,
+              zero-tolerance storage-contract enforcement, and the
+              nightly chaos soak with a restore-proof gate.
+tags:
+  - integrity
+  - drill
+  - doctor
+  - chaos
+  - testing
+---
+
+# Integrity testing
+
+A backup that has never been restored is unproven. This page
+documents the three layers `pg_hardstorage` uses to keep
+"data corruption" and "backup that won't restore" in the class
+of bugs that get caught by machines before they reach an
+operator:
+
+| Layer | Where it runs | What it proves |
+| --- | --- | --- |
+| [Scheduled drills](#scheduled-recovery-drills) | Your production agent | The *latest* backup restores, continuously |
+| [Contract enforcement](#storage-contract-enforcement) | CI, every commit | Storage backends honour concurrency semantics |
+| [Chaos soak](#the-chaos-soak) | Nightly CI | Backups survive failovers, stalls, and races |
+
+The first layer is the one **you** deploy; the other two run in
+the project's CI and are documented here so you can reproduce a
+failure or run the same proofs against your own environment.
+
+---
+
+## Scheduled recovery drills
+
+The agent can run a full [recovery drill](incident-response.md)
+— restore the latest backup into a scratch directory and verify
+it — on a schedule, exactly like `backup` and `rotate` tasks:
+
+```bash
+pg_hardstorage schedule db1 'daily_at 03:00' --task drill
+```
+
+```yaml
+deployments:
+  db1:
+    schedule:
+      backup: { every: "6h" }
+      rotate: { daily_at: "04:00" }
+      drill:  { daily_at: "03:00" }
+```
+
+Every drill — pass or fail — appends an entry to the repo's
+drill history (`recovery/drills/`), so the evidence lives next
+to the backups it proves. A non-pass verdict also fails the
+agent task, which surfaces through the agent's normal
+task-failure event stream and your
+[alerting](alerting-recipes.md).
+
+Convention: drill **after** the typical backup window (backup
+at 02:00 → drill at 03:00) so the drill proves the backup the
+schedule just took, not yesterday's.
+
+### Doctor: drill freshness
+
+`doctor` reads the drill history and alarms when restorability
+is unproven:
+
+| Issue code | Severity | Meaning |
+| --- | --- | --- |
+| `recovery.drill_never_run` | notice | No drill has ever run for this deployment. |
+| `recovery.drill_failing` | critical | The most recent drill did **not** pass. |
+| `recovery.drill_stale` | critical | The last *passing* drill is older than `--drill-max-age` (default **7d**). |
+
+```bash
+pg_hardstorage doctor db1 --drill-max-age 72h
+```
+
+The report body carries a `drills` section per deployment with
+`last_verdict`, `last_at`, `last_pass_at`, and `fresh`, so
+fleet dashboards can chart drill freshness directly from
+`doctor -o json`.
+
+Tune `--drill-max-age` to your drill cadence plus slack: a
+daily drill with the default `7d` window tolerates most of a
+week of drill failures before escalating — for a strict posture
+pair `daily_at` drills with `--drill-max-age 48h`.
+
+---
+
+## Storage contract enforcement
+
+Every storage backend must pass the shared contract suite
+(`internal/plugin/storage/contract`), and since this program
+landed the **concurrency cases are mandatory**, not opt-in:
+
+- **`ParallelPuts_SingleWinner`** — N goroutines race
+  `IfNotExists` puts on one key; exactly one may win and the
+  stored bytes must be the winner's. This is the invariant the
+  shared-DEK mint, the backup lease, and the audit chain all
+  stand on.
+- **`ParallelOverwrites_NoTornContent`** — concurrent
+  overwrites of one key must never leave torn/interleaved
+  content.
+
+The suite is **capability-aware and honesty-enforcing**: a
+backend that reports `ConditionalPut: false` skips the
+single-winner case (its callers degrade loudly instead — see
+below), but a backend that *claims* `ConditionalPut: true` and
+fails the race is red. Lying about capabilities is the failure
+mode; being honest about a limitation is supported.
+
+### Degrading loudly without conditional put
+
+On backends without atomic `IfNotExists`:
+
+- The backup runner emits a warning event
+  (`backup` / `lease_unenforceable`) before taking the lease,
+  so overlapping-writer risk is visible in the event stream
+  rather than silent.
+- The audit chain re-reads every slot it "won" and treats a
+  mismatch as a lost race, preserving hash-chain integrity even
+  when the backend can't referee the race itself.
+
+### CI demand mode
+
+The contract jobs run with the `DEMAND` variables set, which
+turn "environment missing → skip" into "environment missing →
+fail" — a contract test can never silently stop running in CI:
+
+```bash
+PG_HARDSTORAGE_DEMAND_DOCKER=1   # sftp / MinIO fixtures must start
+PG_HARDSTORAGE_DEMAND_SSHD=1     # the real-sshd scp fixture must start
+```
+
+The scp backend is exercised against a **real `sshd`** (not a
+mock), which is how its production session-open retry under
+`MaxSessions` backpressure was found and fixed.
+
+---
+
+## The chaos soak
+
+The nightly `chaos-soak` workflow runs the production model —
+an **encrypted** repo, a **continuous** `wal stream`, scheduled
+backups, constant write churn — over a real 3-node Patroni
+cluster while injecting a seeded random fault schedule:
+
+| Fault | Models |
+| --- | --- |
+| `switchover` | Planned Patroni failover (the #34 shape) |
+| `pause_leader` | GC stall / VM freeze on the primary (3–8 s `docker pause`) |
+| `backup_burst` | Two concurrent backups racing the streamer (the #31 shape) |
+| `none` | Quiet round — steady-state must also stay clean |
+
+Two rules are encoded from post-mortems:
+
+1. **Processes are never restarted** unless restart *is* the
+   injected fault. (A restart-tolerant harness masked the #34
+   switchover hang for months.)
+2. **The pass criterion is never "exit 0".** After the fault
+   budget is spent, the soak enforces a **restore-proof gate**:
+
+   - every committed backup must `verify --full` **and**
+     `restore` cleanly,
+   - `wal audit` must prove the WAL lineage gap-free across all
+     failovers,
+   - exactly **one** shared-DEK object may exist in the repo
+     (two = the #31 divergent-encryption class),
+   - the streamer must still be alive, and stop gracefully on a
+     single `SIGINT`.
+
+!!! note "It works"
+    The very first soak run caught a real bug: `verify --full` ran
+    every backup through a PG18 sandbox regardless of the backup's
+    actual major (a `pg_version` parsing slip), so PG17 backups
+    failed with `pg_control: CRC is incorrect` despite being fully
+    restorable. The restore-proof gate flagged all 32 backups;
+    `recovery drill` — which resolves the major correctly — passed
+    them, and the diff between the two paths pinpointed the bug.
+
+### Running it yourself
+
+```bash
+go build -o /tmp/pghs ./cmd/pg_hardstorage
+PGHS_CHAOS_BIN=/tmp/pghs PGHS_CHAOS_MINUTES=6 \
+    go test -run TestChaosSoak_RestoreProof -timeout 30m -v \
+    ./internal/testkit/topology/
+```
+
+Needs Docker and pulls the Spilo + etcd images on first run.
+The nightly job uses a 45-minute budget;
+`workflow_dispatch` accepts a custom `minutes` input.
+
+### Reproducing a failure
+
+Every run logs its fault-schedule seed:
+
+```console
+chaos soak: budget=45m seed=1784835364… (re-run with PGHS_CHAOS_SEED=…)
+```
+
+Re-running with `PGHS_CHAOS_SEED=<seed>` (or the workflow's
+`seed` input) replays the identical fault sequence, so a red
+nightly is a deterministic repro, not a shrug.
+
+---
+
+## Next steps
+
+- [Incident response](incident-response.md) — out-of-cycle
+  drills during an incident
+- [Schedule backups](../how-to/operating/schedule-backups.md) —
+  the `schedule` subcommand, including `--task drill`
+- [Alerting recipes](alerting-recipes.md) — wire drill
+  failures and doctor criticals into your pager

--- a/docs/reference/cli/pg_hardstorage_doctor.md
+++ b/docs/reference/cli/pg_hardstorage_doctor.md
@@ -25,8 +25,9 @@ pg_hardstorage doctor [<deployment>] [flags]
 ### Options
 
 ```
-      --exit-on-issues   exit with code 10 (ExitDoctorIssues) when the report contains issues at warning+ severity; useful for cron / k8s liveness probes
-  -h, --help             help for doctor
+      --drill-max-age duration   maximum age of the last SUCCESSFUL recovery drill before doctor escalates recovery.drill_stale (CRITICAL) (default 168h0m0s)
+      --exit-on-issues           exit with code 10 (ExitDoctorIssues) when the report contains issues at warning+ severity; useful for cron / k8s liveness probes
+  -h, --help                     help for doctor
 ```
 
 ### Options inherited from parent commands

--- a/docs/reference/cli/pg_hardstorage_schedule.md
+++ b/docs/reference/cli/pg_hardstorage_schedule.md
@@ -38,7 +38,7 @@ pg_hardstorage schedule [<deployment> [<expression>]] [flags]
 
 ```
   -h, --help          help for schedule
-      --task string   which task's schedule to inspect/modify: backup | rotate (default "backup")
+      --task string   which task's schedule to inspect/modify: backup | rotate | drill (default "backup")
 ```
 
 ### Options inherited from parent commands

--- a/internal/agent/verify_executor.go
+++ b/internal/agent/verify_executor.go
@@ -237,6 +237,14 @@ func pgMajorFromManifestVersion(v int) string {
 	if v <= 0 {
 		return fallback
 	}
+	// The runner stores the plain major (pg_version=17); the MMmmpp
+	// division applies only to the numeric server_version_num form.
+	// Without this, 17/10000=0 routed every scheduled verify into a
+	// pg.DefaultSandboxMajor sandbox whose pg_verifybackup rejects
+	// older majors' pg_control ("CRC is incorrect").
+	if v < 100 {
+		return fmt.Sprintf("%d", v)
+	}
 	major := v / 10000
 	if major <= 0 {
 		return fallback

--- a/internal/agent/verify_executor_major_test.go
+++ b/internal/agent/verify_executor_major_test.go
@@ -1,0 +1,31 @@
+package agent
+
+import (
+	"fmt"
+	"testing"
+
+	"github.com/cybertec-postgresql/pg_hardstorage/internal/pg"
+)
+
+// Mirror of the regression in internal/cli/verify_full_major_test.go:
+// manifests store the plain major (pg_version=17), and the pre-fix
+// helper divided it to 0 → pg.DefaultSandboxMajor — so every
+// agent-scheduled verify ran the wrong-major sandbox and failed
+// healthy backups with "pg_control: CRC is incorrect".
+func TestPGMajorFromManifestVersion(t *testing.T) {
+	fallback := fmt.Sprintf("%d", pg.DefaultSandboxMajor)
+	cases := []struct {
+		in   int
+		want string
+	}{
+		{17, "17"},     // the regression: plain major
+		{16, "16"},     // plain major, older
+		{170004, "17"}, // server_version_num style
+		{0, fallback},  // unparseable → default
+	}
+	for _, tc := range cases {
+		if got := pgMajorFromManifestVersion(tc.in); got != tc.want {
+			t.Errorf("pgMajorFromManifestVersion(%d) = %q, want %q", tc.in, got, tc.want)
+		}
+	}
+}

--- a/internal/audit/append_noconditional_test.go
+++ b/internal/audit/append_noconditional_test.go
@@ -1,0 +1,120 @@
+package audit
+
+import (
+	"bytes"
+	"context"
+	"io"
+	"net/url"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/cybertec-postgresql/pg_hardstorage/internal/plugin/storage"
+	"github.com/cybertec-postgresql/pg_hardstorage/internal/plugin/storage/fs"
+)
+
+// lyingAuditSP models a backend whose IfNotExists is last-writer-wins
+// and which HONESTLY reports ConditionalPut=false (e.g. sftp without
+// the hardlink extension). For one chosen slot key it simulates a
+// concurrent winner: the caller's put "succeeds" but the stored bytes
+// end up being the OTHER writer's.
+type lyingAuditSP struct {
+	storage.StoragePlugin
+	stompKey  string
+	stompWith []byte
+	stomped   bool
+}
+
+func (l *lyingAuditSP) Capabilities() storage.Capabilities {
+	return storage.Capabilities{ConditionalPut: false}
+}
+
+func (l *lyingAuditSP) Put(ctx context.Context, key string, r io.Reader, opts storage.PutOptions) (storage.PutResult, error) {
+	body, err := io.ReadAll(r)
+	if err != nil {
+		return storage.PutResult{}, err
+	}
+	opts.IfNotExists = false // the lie: overwrite, never ErrAlreadyExists
+	if key == l.stompKey && !l.stomped {
+		// The concurrent winner's bytes land "after" ours.
+		l.stomped = true
+		body = l.stompWith
+	}
+	opts.ContentLength = int64(len(body))
+	return l.StoragePlugin.Put(ctx, key, bytes.NewReader(body), opts)
+}
+
+// Regression (concurrency audit): on a no-ConditionalPut backend, a
+// "won" Append whose slot was actually taken by a concurrent writer
+// must DETECT the loss via read-back and relink onto the next slot —
+// the old behavior returned success while the event bytes were silently
+// replaced, an invisible loss in a tamper-evident log.
+func TestAppend_NoConditionalPut_ReadBackDetectsLostSlot(t *testing.T) {
+	dir := t.TempDir()
+	inner := &fs.Plugin{}
+	if err := inner.Open(context.Background(), storage.StorageConfig{URL: &url.URL{Scheme: "file", Path: dir}}); err != nil {
+		t.Fatal(err)
+	}
+	defer inner.Close()
+
+	// First, on a scratch prefix... simpler: produce the WINNER event
+	// bytes by running a normal Append on a sibling store rooted at a
+	// different dir with the same (empty) chain state, then capture the
+	// slot-0 object it wrote.
+	wdir := t.TempDir()
+	winner := &fs.Plugin{}
+	if err := winner.Open(context.Background(), storage.StorageConfig{URL: &url.URL{Scheme: "file", Path: wdir}}); err != nil {
+		t.Fatal(err)
+	}
+	defer winner.Close()
+	ws := NewStore(winner)
+	if err := ws.Append(context.Background(), &Event{Action: "winner.event", Timestamp: time.Now().UTC()}); err != nil {
+		t.Fatalf("winner append: %v", err)
+	}
+	var winnerKey string
+	var winnerBytes []byte
+	for info, err := range winner.List(context.Background(), "audit/") {
+		if err != nil {
+			t.Fatal(err)
+		}
+		if strings.HasSuffix(info.Key, ".json") && info.Key != HeadKey {
+			winnerKey = info.Key
+			rc, _ := winner.Get(context.Background(), info.Key)
+			winnerBytes, _ = io.ReadAll(rc)
+			rc.Close()
+		}
+	}
+	if winnerKey == "" || len(winnerBytes) == 0 {
+		t.Fatal("could not capture winner slot object")
+	}
+
+	sp := &lyingAuditSP{StoragePlugin: inner, stompKey: winnerKey, stompWith: winnerBytes}
+	s := NewStore(sp)
+	if err := s.Append(context.Background(), &Event{Action: "mine.event", Timestamp: time.Now().UTC()}); err != nil {
+		t.Fatalf("append: %v", err)
+	}
+
+	// BOTH events must exist: the winner at slot 0 and ours relinked
+	// at slot 1. The pre-fix behavior left only the winner (our event
+	// silently lost) while Append reported success.
+	var actions []string
+	for info, err := range inner.List(context.Background(), "audit/") {
+		if err != nil {
+			t.Fatal(err)
+		}
+		if !strings.HasSuffix(info.Key, ".json") || info.Key == HeadKey {
+			continue
+		}
+		rc, _ := inner.Get(context.Background(), info.Key)
+		b, _ := io.ReadAll(rc)
+		rc.Close()
+		actions = append(actions, string(b))
+	}
+	joined := strings.Join(actions, "\n")
+	if !strings.Contains(joined, "winner.event") {
+		t.Error("winner event missing")
+	}
+	if !strings.Contains(joined, "mine.event") {
+		t.Error("OUR event was silently lost (pre-fix behavior): read-back did not detect the stomped slot")
+	}
+}

--- a/internal/audit/audit.go
+++ b/internal/audit/audit.go
@@ -453,6 +453,20 @@ func (s *Store) Append(ctx context.Context, ev *Event) error {
 			putOpts.RetentionMode = storage.WORMMode(s.worm.Mode)
 		}
 		_, err = s.sp.Put(ctx, key, bytes.NewReader(body), putOpts)
+		if err == nil && !s.sp.Capabilities().ConditionalPut {
+			// The backend makes NO single-winner promise (honest
+			// ConditionalPut=false — e.g. an sftp server without the
+			// hardlink extension): two concurrent Appends can both
+			// "win" the slot, and the later write silently replaces
+			// the earlier event — invisible loss in a tamper-evident
+			// log, since the surviving chain stays self-consistent
+			// (concurrency audit). Read the slot back; if the stored
+			// bytes aren't ours we actually lost — take the
+			// lost-the-race path and relink onto the winner.
+			if stored, rerr := s.readSlotRaw(ctx, key); rerr != nil || !bytes.Equal(stored, body) {
+				err = storage.ErrAlreadyExists
+			}
+		}
 		if err == nil {
 			// Won the slot. Update the head pointer. A failure here is
 			// non-fatal — the event itself is committed; the next Append
@@ -1153,3 +1167,15 @@ func realRandomBytes(n int) []byte {
 // pulling crypto/rand into them. Variable is overridden via the
 // test_hooks file.
 var randRead = cryptoRandRead
+
+// readSlotRaw fetches the raw bytes at an event-slot key. Used by the
+// no-ConditionalPut read-back verification in Append.
+func (s *Store) readSlotRaw(ctx context.Context, key string) ([]byte, error) {
+	rc, err := s.sp.Get(ctx, key)
+	if err != nil {
+		return nil, err
+	}
+	defer rc.Close()
+	// Events are small JSON docs; 1 MiB is far above any legitimate size.
+	return stdio.ReadAll(stdio.LimitReader(rc, 1<<20))
+}

--- a/internal/backup/runner/runner.go
+++ b/internal/backup/runner/runner.go
@@ -446,6 +446,17 @@ func Take(ctx context.Context, opts TakeOptions) (*Result, error) {
 	//     holder's lease expires and is reclaimed automatically; a
 	//     long backup is kept alive by the Maintain goroutine below.
 	if !opts.SkipLease {
+		// Loud degradation on backends without an atomic conditional
+		// put (honest ConditionalPut=false): the lease's mutual
+		// exclusion is not guaranteed there, and the operator should
+		// know rather than discover it as two overlapping backups.
+		if !sp.Capabilities().ConditionalPut {
+			emit(output.NewEvent(output.SeverityWarning, "backup", "lease_unenforceable").
+				WithSubject(output.Subject{Deployment: opts.Deployment}).
+				WithBody(map[string]any{
+					"message": "this storage backend cannot perform an atomic conditional write, so the backup lease cannot strictly guarantee a single concurrent backup; avoid running overlapping backups of this deployment from multiple hosts",
+				}))
+		}
 		lease, lerr := backup.AcquireBackupLease(ctx, sp, opts.Deployment, backup.LeaseOptions{Owner: opts.LeaseOwner})
 		if lerr != nil {
 			if errors.Is(lerr, backup.ErrBackupInProgress) {

--- a/internal/cli/agent.go
+++ b/internal/cli/agent.go
@@ -30,6 +30,7 @@ import (
 	"github.com/cybertec-postgresql/pg_hardstorage/internal/paths"
 	"github.com/cybertec-postgresql/pg_hardstorage/internal/patroni"
 	"github.com/cybertec-postgresql/pg_hardstorage/internal/plugin/storage"
+	"github.com/cybertec-postgresql/pg_hardstorage/internal/recovery"
 	"github.com/cybertec-postgresql/pg_hardstorage/internal/repo"
 	"github.com/cybertec-postgresql/pg_hardstorage/internal/schedule"
 	"github.com/cybertec-postgresql/pg_hardstorage/internal/version"
@@ -462,8 +463,59 @@ func buildAgentTasks(engine *schedule.Engine, deps map[string]config.DeploymentC
 				count++
 			}
 		}
+		if !dep.Schedule.Drill.IsZero() {
+			task, err := buildDrillTask(name, dep, verifier)
+			if err != nil {
+				errs = append(errs, agentTaskAddError{Deployment: name, Task: "drill", Err: err})
+			} else if err := engine.Add(task); err != nil {
+				errs = append(errs, agentTaskAddError{Deployment: name, Task: "drill", Err: err})
+			} else {
+				count++
+			}
+		}
 	}
 	return count, errs
+}
+
+// buildDrillTask produces a schedule.Task that runs a full recovery
+// drill (restore the latest backup into a temp dir + sandbox verify)
+// and records the verdict in the repo's drill history. This is the
+// continuous restorability probe: a backup that has never been
+// restored is unproven, and `doctor` alarms when the last successful
+// drill goes stale. Drill() appends its history entry on every run
+// (pass/partial/fail), so even a failing drill leaves evidence for
+// doctor to surface; a non-pass verdict also errors the task so the
+// agent emits its task-failure event.
+func buildDrillTask(name string, dep config.DeploymentConfig, verifier *backup.Verifier) (*schedule.Task, error) {
+	if dep.Repo == "" {
+		return nil, errors.New("missing repo")
+	}
+	sched, err := schedule.Parse(schedule.Spec(dep.Schedule.Drill))
+	if err != nil {
+		return nil, err
+	}
+	return &schedule.Task{
+		Name:     "drill:" + name,
+		Schedule: sched,
+		Run: func(ctx context.Context) error {
+			opts := recovery.DrillOptions{Verifier: verifier}
+			// Wire the keystore exactly like the CLI drill command does —
+			// without a KEKResolver/DEKUnwrapper every drill against an
+			// encrypted repo fails instantly at the restore phase.
+			if p, perr := paths.Resolve(paths.DefaultOptions()); perr == nil {
+				opts.KEKResolver = recovery.KeystoreKEKResolver(p.Keyring.Value)
+				opts.DEKUnwrapper = recovery.KeystoreDEKResolver(p.Keyring.Value)
+			}
+			report, err := recovery.Drill(ctx, dep.Repo, name, opts)
+			if err != nil {
+				return fmt.Errorf("drill: %w", err)
+			}
+			if report.Verdict != recovery.DrillVerdictPass {
+				return fmt.Errorf("drill verdict %q for %s — latest backup did not prove restorable", report.Verdict, name)
+			}
+			return nil
+		},
+	}, nil
 }
 
 // buildBackupTask produces a schedule.Task that runs runner.Take.

--- a/internal/cli/agent_drill_task_test.go
+++ b/internal/cli/agent_drill_task_test.go
@@ -1,0 +1,36 @@
+package cli
+
+import (
+	"testing"
+
+	"github.com/cybertec-postgresql/pg_hardstorage/internal/config"
+)
+
+// The drill schedule registers an agent task like backup/rotate do
+// (continuous-restorability probe, integrity program #3).
+func TestBuildDrillTask(t *testing.T) {
+	dep := config.DeploymentConfig{
+		Repo:     "file:///tmp/x",
+		Schedule: config.DeploymentSchedule{Drill: config.ScheduleSpec{DailyAt: "03:00"}},
+	}
+	task, err := buildDrillTask("db1", dep, nil)
+	if err != nil {
+		t.Fatalf("buildDrillTask: %v", err)
+	}
+	if task.Name != "drill:db1" {
+		t.Errorf("task name = %q, want drill:db1", task.Name)
+	}
+	// Missing repo must refuse at registration, not at fire time.
+	if _, err := buildDrillTask("db1", config.DeploymentConfig{
+		Schedule: config.DeploymentSchedule{Drill: config.ScheduleSpec{Every: "24h"}},
+	}, nil); err == nil {
+		t.Error("missing repo accepted")
+	}
+	// Bad spec refused.
+	if _, err := buildDrillTask("db1", config.DeploymentConfig{
+		Repo:     "file:///tmp/x",
+		Schedule: config.DeploymentSchedule{Drill: config.ScheduleSpec{Every: "not-a-duration"}},
+	}, nil); err == nil {
+		t.Error("bad schedule spec accepted")
+	}
+}

--- a/internal/cli/doctor.go
+++ b/internal/cli/doctor.go
@@ -24,6 +24,7 @@ import (
 	"github.com/cybertec-postgresql/pg_hardstorage/internal/paths"
 	"github.com/cybertec-postgresql/pg_hardstorage/internal/pg"
 	"github.com/cybertec-postgresql/pg_hardstorage/internal/plugin/storage"
+	"github.com/cybertec-postgresql/pg_hardstorage/internal/recovery"
 	"github.com/cybertec-postgresql/pg_hardstorage/internal/repo"
 	"github.com/cybertec-postgresql/pg_hardstorage/internal/wal/gapstate"
 )
@@ -52,6 +53,8 @@ func newRealDoctorCmd() *cobra.Command {
 	c.Flags().Bool("exit-on-issues", false,
 		"exit with code 10 (ExitDoctorIssues) when the report contains issues at warning+ severity; "+
 			"useful for cron / k8s liveness probes")
+	c.Flags().Duration("drill-max-age", defaultDrillMaxAge,
+		"maximum age of the last SUCCESSFUL recovery drill before doctor escalates recovery.drill_stale (CRITICAL)")
 	return c
 }
 
@@ -96,6 +99,8 @@ func runDoctor(cmd *cobra.Command, _ []string) error {
 		report.ExpiredHolds, report.Issues = appendExpiredHoldChecks(cmd.Context(), cfg, report.Issues)
 		report.PGVersions, report.Issues = appendPGVersionChecks(cmd.Context(), cfg, report.Issues)
 		report.ManifestSig, report.Issues = appendManifestSignatureChecks(cmd.Context(), cfg, report.Issues)
+		drillMaxAge, _ := cmd.Flags().GetDuration("drill-max-age")
+		report.Drills, report.Issues = appendDrillChecks(cmd.Context(), cfg, drillMaxAge, report.Issues)
 	}
 
 	// Recompute Healthy from the FINAL issue set. buildDoctorReport
@@ -569,6 +574,123 @@ func appendRepoChecks(ctx context.Context, cfg *config.LoadResult, issues []doct
 	return out, issues
 }
 
+// drillStatusReport summarises one deployment's recovery-drill
+// freshness — the continuous "is the latest backup provably
+// restorable?" probe. A backup that has never been restored is
+// unproven; drills turn exit-0 backups into demonstrated restores,
+// and this report is how an operator sees that proof go stale.
+type drillStatusReport struct {
+	Deployment  string `json:"deployment"`
+	Repo        string `json:"repo"`
+	LastVerdict string `json:"last_verdict,omitempty"`
+	LastAt      string `json:"last_at,omitempty"`
+	LastPassAt  string `json:"last_pass_at,omitempty"`
+	Fresh       bool   `json:"fresh"`
+}
+
+// defaultDrillMaxAge is how old the last SUCCESSFUL drill may be
+// before doctor escalates. One week matches a weekly drill schedule
+// with a day of slack.
+const defaultDrillMaxAge = 7 * 24 * time.Hour
+
+// appendDrillChecks reads each deployment's drill history
+// (recovery/drills/ in its repo) and flags:
+//
+//   - recovery.drill_never_run  (notice)  — no drill has ever run;
+//     the backups are unproven. Suggests scheduling one.
+//   - recovery.drill_failing    (CRITICAL) — the most recent drill
+//     did not pass: the latest backup could not be proven restorable.
+//   - recovery.drill_stale      (CRITICAL) — the last PASSING drill
+//     is older than maxAge: restorability is no longer being proven.
+func appendDrillChecks(ctx context.Context, cfg *config.LoadResult, maxAge time.Duration, issues []doctorIssue) ([]drillStatusReport, []doctorIssue) {
+	if maxAge <= 0 {
+		maxAge = defaultDrillMaxAge
+	}
+	names := make([]string, 0, len(cfg.Config.Deployments))
+	for name := range cfg.Config.Deployments {
+		names = append(names, name)
+	}
+	sort.Strings(names)
+
+	var out []drillStatusReport
+	now := time.Now().UTC()
+	for _, name := range names {
+		dep := cfg.Config.Deployments[name]
+		if dep.Repo == "" {
+			continue
+		}
+		_, sp, err := repo.Open(ctx, dep.Repo)
+		if err != nil {
+			continue // repo.unreachable already surfaced by appendRepoChecks
+		}
+		entries, herr := recovery.NewHistoryStore(sp).List(ctx, recovery.HistoryFilter{
+			Deployment: name,
+			Reverse:    true,
+			Limit:      50,
+		})
+		sp.Close()
+		if herr != nil {
+			continue // best-effort, like the other doctor probes
+		}
+		rep := drillStatusReport{Deployment: name, Repo: dep.Repo}
+		if len(entries) == 0 {
+			out = append(out, rep)
+			issues = append(issues, doctorIssue{
+				Severity: output.SeverityNotice,
+				Code:     "recovery.drill_never_run",
+				Message:  fmt.Sprintf("doctor: deployment %q has never run a recovery drill — its backups are unproven (a backup that has never been restored is not known to be restorable)", name),
+				Suggestion: &output.Suggestion{
+					Human:   fmt.Sprintf("schedule a periodic drill: `pg_hardstorage schedule %s \"daily_at 03:00\" --task drill` (the agent runs it), or run one now with `pg_hardstorage recovery drill %s --repo %s`", name, name, dep.Repo),
+					Command: fmt.Sprintf("pg_hardstorage recovery drill %s --repo %s", name, dep.Repo),
+				},
+			})
+			continue
+		}
+		latest := entries[0]
+		rep.LastVerdict = string(latest.Verdict)
+		rep.LastAt = latest.GeneratedAt.UTC().Format(time.RFC3339)
+		var lastPass *recovery.DrillHistoryEntry
+		for _, e := range entries {
+			if e.Verdict == recovery.DrillVerdictPass {
+				lastPass = e
+				break
+			}
+		}
+		if lastPass != nil {
+			rep.LastPassAt = lastPass.GeneratedAt.UTC().Format(time.RFC3339)
+		}
+		if latest.Verdict != recovery.DrillVerdictPass {
+			issues = append(issues, doctorIssue{
+				Severity: output.SeverityCritical,
+				Code:     "recovery.drill_failing",
+				Message:  fmt.Sprintf("doctor: the most recent recovery drill for %q FAILED (verdict %q at %s, backup %s) — the latest backup could not be proven restorable", name, latest.Verdict, rep.LastAt, latest.BackupID),
+				Suggestion: &output.Suggestion{
+					Human:   "investigate immediately: run the drill by hand with --keep-target-dir and inspect; a failing drill means a restore during a real incident would likely fail the same way",
+					Command: fmt.Sprintf("pg_hardstorage recovery drill %s --repo %s", name, dep.Repo),
+				},
+			})
+			out = append(out, rep)
+			continue
+		}
+		if now.Sub(lastPass.GeneratedAt) > maxAge {
+			issues = append(issues, doctorIssue{
+				Severity: output.SeverityCritical,
+				Code:     "recovery.drill_stale",
+				Message:  fmt.Sprintf("doctor: last successful recovery drill for %q was %s (> %s ago) — restorability is no longer being proven", name, rep.LastPassAt, maxAge),
+				Suggestion: &output.Suggestion{
+					Human:   fmt.Sprintf("check the agent's drill schedule (`pg_hardstorage schedule %s --task drill`) and the agent's health; or run a drill now", name),
+					Command: fmt.Sprintf("pg_hardstorage recovery drill %s --repo %s", name, dep.Repo),
+				},
+			})
+			out = append(out, rep)
+			continue
+		}
+		rep.Fresh = true
+		out = append(out, rep)
+	}
+	return out, issues
+}
+
 // checkOneRepo runs the read-only health probes against one
 // repo URL. Errors at any stage are captured in the report's
 // fields + surfaced via doctorIssue entries; the function never
@@ -731,6 +853,7 @@ type doctorReport struct {
 	ExpiredHolds []expiredHoldReport `json:"expired_holds,omitempty"`
 	PGVersions   []pgVersionReport   `json:"pg_versions,omitempty"`
 	ManifestSig  []manifestSigReport `json:"manifest_signatures,omitempty"`
+	Drills       []drillStatusReport `json:"drills,omitempty"`
 	Issues       []doctorIssue       `json:"issues,omitempty"`
 	Healthy      bool                `json:"healthy"`
 }

--- a/internal/cli/doctor_drill_test.go
+++ b/internal/cli/doctor_drill_test.go
@@ -1,0 +1,107 @@
+package cli
+
+import (
+	"context"
+	"net/url"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/cybertec-postgresql/pg_hardstorage/internal/config"
+	"github.com/cybertec-postgresql/pg_hardstorage/internal/plugin/storage"
+	"github.com/cybertec-postgresql/pg_hardstorage/internal/plugin/storage/fs"
+	"github.com/cybertec-postgresql/pg_hardstorage/internal/recovery"
+	"github.com/cybertec-postgresql/pg_hardstorage/internal/repo"
+)
+
+// drillDoctorWorld plants a repo with optional drill-history entries and
+// returns a LoadResult wired to it.
+func drillDoctorWorld(t *testing.T, entries ...*recovery.DrillHistoryEntry) (*config.LoadResult, string) {
+	t.Helper()
+	dir := t.TempDir()
+	repoURL := "file://" + dir
+	if _, err := repo.Init(context.Background(), repo.InitOptions{URL: repoURL}); err != nil {
+		t.Fatalf("repo init: %v", err)
+	}
+	sp := &fs.Plugin{}
+	if err := sp.Open(context.Background(), storage.StorageConfig{URL: &url.URL{Scheme: "file", Path: dir}}); err != nil {
+		t.Fatal(err)
+	}
+	defer sp.Close()
+	hs := recovery.NewHistoryStore(sp)
+	for _, e := range entries {
+		if err := hs.Append(context.Background(), e); err != nil {
+			t.Fatalf("plant drill entry: %v", err)
+		}
+	}
+	cfg := &config.LoadResult{}
+	cfg.Config.Schema = config.Schema
+	cfg.Config.Deployments = map[string]config.DeploymentConfig{
+		"db1": {Repo: repoURL},
+	}
+	return cfg, repoURL
+}
+
+func drillEntry(id string, verdict recovery.DrillVerdict, at time.Time) *recovery.DrillHistoryEntry {
+	return &recovery.DrillHistoryEntry{
+		ID:          id,
+		Deployment:  "db1",
+		BackupID:    "db1.full.x",
+		Verdict:     verdict,
+		GeneratedAt: at,
+		StoppedAt:   at.Add(time.Minute),
+	}
+}
+
+func issueCodes(issues []doctorIssue) string {
+	var b strings.Builder
+	for _, i := range issues {
+		b.WriteString(i.Code + " ")
+	}
+	return b.String()
+}
+
+// The continuous-restorability probe (concurrency/integrity program #3):
+// doctor must surface never-run (notice), failing (CRITICAL), stale
+// (CRITICAL), and stay quiet when the last pass is fresh.
+func TestAppendDrillChecks_Verdicts(t *testing.T) {
+	now := time.Now().UTC()
+
+	t.Run("never_run_notice", func(t *testing.T) {
+		cfg, _ := drillDoctorWorld(t)
+		_, issues := appendDrillChecks(context.Background(), cfg, 0, nil)
+		if !strings.Contains(issueCodes(issues), "recovery.drill_never_run") {
+			t.Errorf("want drill_never_run; got %q", issueCodes(issues))
+		}
+	})
+
+	t.Run("fresh_pass_is_quiet", func(t *testing.T) {
+		cfg, _ := drillDoctorWorld(t, drillEntry("2000000000-db1-aaaa", recovery.DrillVerdictPass, now.Add(-2*time.Hour)))
+		reps, issues := appendDrillChecks(context.Background(), cfg, 0, nil)
+		if len(issues) != 0 {
+			t.Errorf("fresh pass produced issues: %q", issueCodes(issues))
+		}
+		if len(reps) != 1 || !reps[0].Fresh {
+			t.Errorf("report = %+v, want Fresh=true", reps)
+		}
+	})
+
+	t.Run("stale_pass_is_critical", func(t *testing.T) {
+		cfg, _ := drillDoctorWorld(t, drillEntry("1000000000-db1-aaaa", recovery.DrillVerdictPass, now.Add(-30*24*time.Hour)))
+		_, issues := appendDrillChecks(context.Background(), cfg, 7*24*time.Hour, nil)
+		if !strings.Contains(issueCodes(issues), "recovery.drill_stale") {
+			t.Fatalf("want drill_stale; got %q", issueCodes(issues))
+		}
+	})
+
+	t.Run("latest_fail_is_critical", func(t *testing.T) {
+		cfg, _ := drillDoctorWorld(t,
+			drillEntry("1000000000-db1-aaaa", recovery.DrillVerdictPass, now.Add(-3*time.Hour)),
+			drillEntry("2000000000-db1-bbbb", recovery.DrillVerdictFail, now.Add(-1*time.Hour)),
+		)
+		_, issues := appendDrillChecks(context.Background(), cfg, 0, nil)
+		if !strings.Contains(issueCodes(issues), "recovery.drill_failing") {
+			t.Fatalf("want drill_failing; got %q", issueCodes(issues))
+		}
+	})
+}

--- a/internal/cli/schedule.go
+++ b/internal/cli/schedule.go
@@ -65,12 +65,12 @@ deployments without a schedule configured.`,
 		},
 	}
 	c.Flags().StringVar(&task, "task", "backup",
-		"which task's schedule to inspect/modify: backup | rotate")
+		"which task's schedule to inspect/modify: backup | rotate | drill")
 	return c
 }
 
 // runScheduleList walks every deployment in the loaded config and
-// emits one row per (deployment, task) pair — both backup and
+// emits one row per (deployment, task) pair — backup, drill, and
 // rotate, even when one or both are unset. An unset slot shows
 // "off" so an operator immediately sees deployments without a
 // schedule.
@@ -92,7 +92,7 @@ func runScheduleList(cmd *cobra.Command) error {
 	rows := make([]scheduleListRow, 0, 2*len(names))
 	for _, name := range names {
 		dep := cfg.Deployments[name]
-		for _, task := range []string{"backup", "rotate"} {
+		for _, task := range []string{"backup", "rotate", "drill"} {
 			spec, _ := selectScheduleSpec(dep, task)
 			row := scheduleListRow{
 				Deployment: name,
@@ -135,7 +135,14 @@ func (b scheduleListBody) WriteText(w io.Writer) error {
 		_, err := io.WriteString(w, strings.TrimRight(bw.String(), "\n"))
 		return err
 	}
-	fmt.Fprintf(bw, "Schedules for %d deployment(s):\n", len(b.Schedules)/2)
+	// Count distinct deployments — never divide by a per-deployment
+	// row constant (that broke silently when the drill task added a
+	// third row per deployment).
+	seen := make(map[string]struct{}, len(b.Schedules))
+	for _, r := range b.Schedules {
+		seen[r.Deployment] = struct{}{}
+	}
+	fmt.Fprintf(bw, "Schedules for %d deployment(s):\n", len(seen))
 	tw := tabwriter.NewWriter(bw, 0, 4, 2, ' ', 0)
 	fmt.Fprintln(tw, "  DEPLOYMENT\tTASK\tWHEN")
 	for _, r := range b.Schedules {
@@ -225,9 +232,11 @@ func selectScheduleSpec(dep config.DeploymentConfig, task string) (config.Schedu
 		return dep.Schedule.Backup, nil
 	case "rotate":
 		return dep.Schedule.Rotate, nil
+	case "drill":
+		return dep.Schedule.Drill, nil
 	default:
 		return config.ScheduleSpec{}, output.NewError("usage.bad_task",
-			fmt.Sprintf("schedule: unknown --task %q (allowed: backup, rotate)", task)).
+			fmt.Sprintf("schedule: unknown --task %q (allowed: backup, rotate, drill)", task)).
 			Wrap(output.ErrUsage)
 	}
 }
@@ -240,9 +249,11 @@ func setScheduleSpec(dep *config.DeploymentConfig, task string, spec config.Sche
 		dep.Schedule.Backup = spec
 	case "rotate":
 		dep.Schedule.Rotate = spec
+	case "drill":
+		dep.Schedule.Drill = spec
 	default:
 		return output.NewError("usage.bad_task",
-			fmt.Sprintf("schedule: unknown --task %q (allowed: backup, rotate)", task)).
+			fmt.Sprintf("schedule: unknown --task %q (allowed: backup, rotate, drill)", task)).
 			Wrap(output.ErrUsage)
 	}
 	return nil

--- a/internal/cli/schedule_list_test.go
+++ b/internal/cli/schedule_list_test.go
@@ -57,11 +57,11 @@ func TestScheduleList_FleetView_JSON(t *testing.T) {
 			t.Errorf("missing %q in:\n%s", want, stdout)
 		}
 	}
-	// db2's rotate task is unset — the row exists but
-	// without a description.
-	// Expect "db2" appears twice (backup + rotate rows).
-	if strings.Count(stdout, `"deployment": "db2"`) != 2 {
-		t.Errorf("expected 2 db2 rows (backup + rotate); got:\n%s", stdout)
+	// db2's rotate and drill tasks are unset — the rows exist
+	// but without a description.
+	// Expect "db2" appears three times (backup + rotate + drill rows).
+	if strings.Count(stdout, `"deployment": "db2"`) != 3 {
+		t.Errorf("expected 3 db2 rows (backup + rotate + drill); got:\n%s", stdout)
 	}
 }
 

--- a/internal/cli/verify_full.go
+++ b/internal/cli/verify_full.go
@@ -187,11 +187,21 @@ func runVerifyFull(cmd *cobra.Command, deployment, backupID, repoURL, pgMajorOve
 	})
 
 	if !res.Passed && !res.Skipped {
-		// Treat as exit code 9 (verify failure).
-		return output.NewError("verify.failed",
-			fmt.Sprintf("verify --full: pg_verifybackup reported failure (see tool_stdout in body)")).
+		// Treat as exit code 9 (verify failure). The tool output must
+		// ride in the message itself — an error Result carries no body,
+		// so pointing the operator at a tool_stdout field that only
+		// exists on success left failures undiagnosable.
+		msg := "verify --full: pg_verifybackup reported failure"
+		// pg_verifybackup writes its findings to stderr, not stdout.
+		if tool := strings.TrimSpace(strings.TrimSpace(res.Stdout) + "\n" + strings.TrimSpace(res.Stderr)); tool != "" {
+			if len(tool) > 2000 {
+				tool = tool[:2000] + " …[truncated]"
+			}
+			msg += ": " + tool
+		}
+		return output.NewError("verify.failed", msg).
 			WithSuggestion(&output.Suggestion{
-				Human: "the backup's bytes are intact (fast verify passed) but pg_verifybackup found a discrepancy. Re-run with --output json to capture the full tool output for triage.",
+				Human: "the backup's bytes are intact (fast verify passed) but pg_verifybackup found a discrepancy in the restored data directory — triage from the tool output above.",
 			})
 	}
 	return d.Result(output.NewResult(cmd.CommandPath()).WithBody(body))
@@ -229,10 +239,18 @@ func resolveDEKForVerify(ctx context.Context, kekRef string, wrapped []byte) ([]
 	return keystore.UnwrapDEK(ctx, kekRef, wrapped, keystore.UnwrapOpts{KeyringDir: keyringDir})
 }
 
-// pgMajorFromManifestVersion extracts the major from PG's
-// numeric_version: PG_VERSION_NUM convention is `MMmmpp` where MM is
-// the major (e.g. 17), mm the minor, pp the patch. PG 10+ collapsed
-// the second digit.
+// pgMajorFromManifestVersion maps a manifest's pg_version to the
+// sandbox major.
+//
+// The runner stores the PLAIN MAJOR (manifest pg_version=17, from
+// probeVersion().Major) — values < 100 are therefore the major
+// itself. The `MMmmpp` PG_VERSION_NUM division only applies to the
+// numeric form (e.g. 170004), kept for manifests written by tools
+// that recorded server_version_num. Before this distinction, 17
+// divided to 0 and EVERY verify --full fell back to
+// pg.DefaultSandboxMajor — a PG18 pg_verifybackup rejecting every
+// healthy PG17 backup with "pg_control: CRC is incorrect" (caught by
+// the chaos soak's restore-proof gate).
 //
 // Falls back to pg.DefaultSandboxMajor (the current upstream-stable
 // major) when v is zero or otherwise unparseable. Single source of
@@ -242,6 +260,9 @@ func pgMajorFromManifestVersion(v int) string {
 	fallback := strconv.Itoa(pg.DefaultSandboxMajor)
 	if v <= 0 {
 		return fallback
+	}
+	if v < 100 {
+		return strconv.Itoa(v)
 	}
 	major := v / 10000
 	if major <= 0 {

--- a/internal/cli/verify_full_major_test.go
+++ b/internal/cli/verify_full_major_test.go
@@ -1,0 +1,44 @@
+package cli
+
+import (
+	"strconv"
+	"testing"
+
+	"github.com/cybertec-postgresql/pg_hardstorage/internal/pg"
+)
+
+// The manifest's pg_version field stores the PLAIN MAJOR (the runner
+// writes probeVersion().Major, e.g. 17) — NOT PG_VERSION_NUM. The
+// pre-fix helper divided every value by 10000, so pg_version=17
+// resolved to major 0 → the pg.DefaultSandboxMajor fallback, and
+// verify --full ran a PG18 pg_verifybackup against every PG17 backup:
+// "pg_control: CRC is incorrect" on provably-healthy backups. Caught
+// by the chaos soak's restore-proof gate (every committed backup
+// failed the full-verify leg while `recovery drill`, which uses the
+// manifest major directly, passed the same backups).
+func TestPGMajorFromManifestVersion(t *testing.T) {
+	fallback := strconv.Itoa(pg.DefaultSandboxMajor)
+	cases := []struct {
+		name string
+		in   int
+		want string
+	}{
+		// The regression: plain majors, as the runner writes them.
+		{"plain_major_17", 17, "17"},
+		{"plain_major_16", 16, "16"},
+		{"plain_major_18", 18, "18"},
+		// server_version_num style still divides.
+		{"version_num_17", 170004, "17"},
+		{"version_num_16", 160011, "16"},
+		// Unparseable → the sandbox default.
+		{"zero", 0, fallback},
+		{"negative", -1, fallback},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			if got := pgMajorFromManifestVersion(tc.in); got != tc.want {
+				t.Errorf("pgMajorFromManifestVersion(%d) = %q, want %q", tc.in, got, tc.want)
+			}
+		})
+	}
+}

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -326,6 +326,13 @@ type DeploymentSchedule struct {
 	Backup      ScheduleSpec `yaml:"backup,omitempty"`
 	Rotate      ScheduleSpec `yaml:"rotate,omitempty"`
 	AuditAnchor ScheduleSpec `yaml:"audit_anchor,omitempty"`
+	// Drill schedules a periodic recovery drill: restore the latest
+	// backup into a sandbox and verify it, recording the verdict in
+	// the repo's drill history. A backup that has never been restored
+	// is unproven — the scheduled drill turns "backup succeeded" into
+	// "backup is restorable", continuously. `doctor` alarms when the
+	// last successful drill is stale.
+	Drill ScheduleSpec `yaml:"drill,omitempty"`
 }
 
 // ScheduleSpec mirrors internal/schedule.Spec exactly; we redeclare
@@ -809,6 +816,9 @@ func mergeDeployment(existing, overlay DeploymentConfig) DeploymentConfig {
 	}
 	if overlay.Schedule.Rotate.Every != "" || overlay.Schedule.Rotate.DailyAt != "" || overlay.Schedule.Rotate.At != "" {
 		existing.Schedule.Rotate = overlay.Schedule.Rotate
+	}
+	if overlay.Schedule.Drill.Every != "" || overlay.Schedule.Drill.DailyAt != "" || overlay.Schedule.Drill.At != "" {
+		existing.Schedule.Drill = overlay.Schedule.Drill
 	}
 	if overlay.Patroni.URL != "" {
 		existing.Patroni.URL = overlay.Patroni.URL

--- a/internal/plugin/storage/contract/contract.go
+++ b/internal/plugin/storage/contract/contract.go
@@ -108,6 +108,20 @@ func Run(t *testing.T, open PluginOpener) {
 			c.fn(t, p)
 		})
 	}
+
+	// Concurrency cases are part of the CORE suite: a backend that
+	// advertises ConditionalPut but loses the single-winner race is a
+	// data-loss bug (the scp `mv -T` emulation silently forked the
+	// shared DEK and destroyed committed audit events — concurrency
+	// audit / issue #31 class). No backend gets to "not yet meet"
+	// these; the only accepted out is HONESTY (ConditionalPut=false),
+	// which ParallelPuts skips-with-reason on.
+	t.Run("ParallelPuts_SingleWinner", func(t *testing.T) {
+		ParallelPuts(t, open, 8)
+	})
+	t.Run("ParallelOverwrites_NoTornContent", func(t *testing.T) {
+		ParallelOverwrites(t, open, 8)
+	})
 }
 
 // putString is a tiny helper — ~80% of contract cases do
@@ -289,18 +303,26 @@ func caseRenameDstPresent(t *testing.T, p storage.StoragePlugin) {
 	}
 }
 
-// ParallelPuts is an extra-stress contract case kept
-// separate so plugins that don't yet meet it don't fail
-// the core suite.  Exercises N concurrent IfNotExists
-// Puts to the same key — exactly ONE must win.  Backends
-// that emulate IfNotExists by check-then-write under
-// concurrent access often fail this.
+// ParallelPuts exercises N concurrent IfNotExists Puts to the same key
+// — exactly ONE must win. This is a MANDATORY case (wired into Run):
+// single-winner consumers (the shared-DEK mint, the backup lease,
+// audit-chain event slots) silently lose data over a backend that
+// claims ConditionalPut but emulates it with check-then-write.
+//
+// The only accepted out is honesty: a backend whose
+// Capabilities().ConditionalPut is FALSE is skipped with a reason —
+// it makes no single-winner promise and the callers that need one
+// degrade loudly at runtime. Claiming true and failing is a red build,
+// never a tolerated known-failure.
 func ParallelPuts(t *testing.T, open PluginOpener, n int) {
 	t.Helper()
 	if n < 2 {
 		n = 8
 	}
 	p := open(t)
+	if !p.Capabilities().ConditionalPut {
+		t.Skipf("backend %q honestly reports ConditionalPut=false — single-winner semantics not claimed (callers degrade loudly)", p.Name())
+	}
 	const key = "parallel/k"
 	var (
 		wg       sync.WaitGroup

--- a/internal/plugin/storage/scp/contract_test.go
+++ b/internal/plugin/storage/scp/contract_test.go
@@ -1,0 +1,186 @@
+// contract_test.go — full storage-contract suite for the scp plugin
+// against a REAL sshd (host OpenSSH, loopback, throwaway keys).
+//
+// Why host sshd instead of a container: the scp plugin needs ssh EXEC
+// (shell commands), which the atmoz/sftp fixture forbids; a local
+// unprivileged sshd on a high port exercises the exact remote-shell
+// primitives production uses — including the atomic `ln -T` commit for
+// IfNotExists (the single-winner guarantee the shared-DEK mint, backup
+// lease and audit chain depend on; concurrency audit / issue #31 class).
+//
+// Skips when /usr/sbin/sshd is absent unless
+// PG_HARDSTORAGE_DEMAND_SSHD=1 (CI sets it so the suite can never
+// silently stop running).
+package scp_test
+
+import (
+	"fmt"
+	"net"
+	"net/url"
+	"os"
+	"os/exec"
+	"os/user"
+	"path/filepath"
+	"testing"
+	"time"
+
+	"github.com/cybertec-postgresql/pg_hardstorage/internal/plugin/storage"
+	"github.com/cybertec-postgresql/pg_hardstorage/internal/plugin/storage/contract"
+	"github.com/cybertec-postgresql/pg_hardstorage/internal/plugin/storage/scp"
+	"golang.org/x/crypto/ssh"
+)
+
+const sshdBin = "/usr/sbin/sshd"
+
+func requireSSHD(t *testing.T) {
+	t.Helper()
+	if _, err := os.Stat(sshdBin); err != nil {
+		if os.Getenv("PG_HARDSTORAGE_DEMAND_SSHD") == "1" {
+			t.Fatalf("PG_HARDSTORAGE_DEMAND_SSHD=1 but %s is missing", sshdBin)
+		}
+		t.Skipf("%s not present; skipping scp-vs-real-sshd contract suite", sshdBin)
+	}
+}
+
+// sshdFixture is one running loopback sshd + the client material to
+// reach it.
+type sshdFixture struct {
+	port       int
+	root       string
+	identity   string
+	knownHosts string
+	user       string
+}
+
+func startSSHD(t *testing.T) *sshdFixture {
+	t.Helper()
+	requireSSHD(t)
+	dir := t.TempDir()
+	u, err := user.Current()
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	// Keys: one host key, one client key (authorized for ourselves).
+	hostKey := filepath.Join(dir, "host_ed25519")
+	clientKey := filepath.Join(dir, "client_ed25519")
+	for _, k := range []string{hostKey, clientKey} {
+		if out, err := exec.Command("ssh-keygen", "-q", "-t", "ed25519", "-N", "", "-f", k).CombinedOutput(); err != nil {
+			t.Fatalf("ssh-keygen %s: %v\n%s", k, err, out)
+		}
+	}
+	authKeys := filepath.Join(dir, "authorized_keys")
+	pub, err := os.ReadFile(clientKey + ".pub")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(authKeys, pub, 0o600); err != nil {
+		t.Fatal(err)
+	}
+
+	// Pick a free port.
+	l, err := net.Listen("tcp", "127.0.0.1:0")
+	if err != nil {
+		t.Fatal(err)
+	}
+	port := l.Addr().(*net.TCPAddr).Port
+	_ = l.Close()
+
+	// Repo root the plugin will operate under.
+	root := filepath.Join(dir, "repo")
+	if err := os.MkdirAll(root, 0o700); err != nil {
+		t.Fatal(err)
+	}
+
+	cfg := filepath.Join(dir, "sshd_config")
+	conf := fmt.Sprintf(`Port %d
+ListenAddress 127.0.0.1
+HostKey %s
+PidFile %s/sshd.pid
+AuthorizedKeysFile %s
+StrictModes no
+PasswordAuthentication no
+KbdInteractiveAuthentication no
+UsePAM no
+Subsystem sftp internal-sftp
+AllowUsers %s
+LogLevel ERROR
+`, port, hostKey, dir, authKeys, u.Username)
+	if err := os.WriteFile(cfg, []byte(conf), 0o600); err != nil {
+		t.Fatal(err)
+	}
+
+	cmd := exec.Command(sshdBin, "-D", "-f", cfg, "-e")
+	if err := cmd.Start(); err != nil {
+		t.Fatalf("start sshd: %v", err)
+	}
+	t.Cleanup(func() { _ = cmd.Process.Kill(); _, _ = cmd.Process.Wait() })
+
+	// Wait for the port, then build known_hosts from the host pubkey
+	// (no keyscan round-trip needed — we own the host key).
+	deadline := time.Now().Add(10 * time.Second)
+	for {
+		c, err := net.DialTimeout("tcp", fmt.Sprintf("127.0.0.1:%d", port), 300*time.Millisecond)
+		if err == nil {
+			_ = c.Close()
+			break
+		}
+		if time.Now().After(deadline) {
+			t.Fatal("sshd did not start listening within 10s")
+		}
+		time.Sleep(100 * time.Millisecond)
+	}
+	hostPub, err := os.ReadFile(hostKey + ".pub")
+	if err != nil {
+		t.Fatal(err)
+	}
+	pk, _, _, _, err := ssh.ParseAuthorizedKey(hostPub)
+	if err != nil {
+		t.Fatal(err)
+	}
+	kh := filepath.Join(dir, "known_hosts")
+	line := fmt.Sprintf("[127.0.0.1]:%d %s %s\n", port, pk.Type(), ssh.FingerprintSHA256(pk))
+	// knownhosts wants the base64 key, not the fingerprint — write the
+	// authorized_keys form re-addressed to the host:port.
+	line = fmt.Sprintf("[127.0.0.1]:%d %s", port, string(hostPub))
+	if err := os.WriteFile(kh, []byte(line), 0o600); err != nil {
+		t.Fatal(err)
+	}
+
+	return &sshdFixture{port: port, root: root, identity: clientKey, knownHosts: kh, user: u.Username}
+}
+
+// openSCPOnFresh satisfies contract.PluginOpener: every call gets a
+// fresh sub-root on the shared sshd so cases are isolated.
+func openSCPOnFresh(t *testing.T) storage.StoragePlugin {
+	t.Helper()
+	fx := startSSHD(t)
+	p := &scp.Plugin{}
+	u := &url.URL{
+		Scheme: "scp",
+		User:   url.User(fx.user),
+		Host:   fmt.Sprintf("127.0.0.1:%d", fx.port),
+		Path:   fx.root,
+	}
+	if err := p.Open(t.Context(), storage.StorageConfig{
+		URL: u,
+		Extras: map[string]string{
+			"identity_file": fx.identity,
+			"known_hosts":   fx.knownHosts,
+		},
+	}); err != nil {
+		t.Fatalf("scp.Open: %v", err)
+	}
+	t.Cleanup(func() { _ = p.Close() })
+	return p
+}
+
+// TestSCP_Contract runs the FULL storage contract — including the
+// mandatory ParallelPuts single-winner and ParallelOverwrites cases —
+// against a real sshd. This is the regression gate for the scp
+// `ln -T` atomic-commit fix: the old stat+`mv -T` emulation failed
+// ParallelPuts (two winners), which is exactly how the #31 DEK-fork
+// class reached scp repos.
+func TestSCP_Contract(t *testing.T) {
+	contract.Run(t, openSCPOnFresh)
+}

--- a/internal/plugin/storage/scp/scp.go
+++ b/internal/plugin/storage/scp/scp.go
@@ -496,8 +496,34 @@ func (p *Plugin) SetRetention(ctx context.Context, key string, until time.Time, 
 //
 // Keep the command line as the sole argument; never interpolate
 // user-controlled keys without `shellQuote()`.
+
+// newSession opens an SSH session with a small bounded retry on
+// channel-open rejection. sshd's default MaxSessions is 10; a burst of
+// concurrent Puts (each using short-lived sessions for upload + commit
+// + cleanup) can transiently exceed it, and the server answers
+// "rejected: connect failed (open failed)". That is backpressure, not
+// failure — retrying after a short jittered pause keeps the plugin
+// correct against DEFAULT sshd configs (the contract suite's
+// ParallelPuts runs against one).
+func (p *Plugin) newSession() (*ssh.Session, error) {
+	var lastErr error
+	for attempt := 0; attempt < 5; attempt++ {
+		sess, err := p.ssh.NewSession()
+		if err == nil {
+			return sess, nil
+		}
+		lastErr = err
+		msg := err.Error()
+		if !strings.Contains(msg, "rejected") && !strings.Contains(msg, "open failed") {
+			return nil, err
+		}
+		time.Sleep(time.Duration(20*(attempt+1)) * time.Millisecond)
+	}
+	return nil, lastErr
+}
+
 func (p *Plugin) runShell(ctx context.Context, command string) (string, error) {
-	sess, err := p.ssh.NewSession()
+	sess, err := p.newSession()
 	if err != nil {
 		return "", fmt.Errorf("scp: new session: %w", err)
 	}
@@ -523,7 +549,7 @@ func (p *Plugin) runShell(ctx context.Context, command string) (string, error) {
 // uploadVia opens a session for command (typically `cat > path`)
 // and streams r to its stdin.  Returns the byte count.
 func (p *Plugin) uploadVia(ctx context.Context, command string, r io.Reader) (int64, error) {
-	sess, err := p.ssh.NewSession()
+	sess, err := p.newSession()
 	if err != nil {
 		return 0, fmt.Errorf("scp: new session: %w", err)
 	}
@@ -576,7 +602,7 @@ func (p *Plugin) uploadVia(ctx context.Context, command string, r io.Reader) (in
 // and returns a ReadCloser that drains stdout.  Closing the
 // reader closes the session.
 func (p *Plugin) streamRead(ctx context.Context, command string) (io.ReadCloser, error) {
-	sess, err := p.ssh.NewSession()
+	sess, err := p.newSession()
 	if err != nil {
 		return nil, fmt.Errorf("scp: new session: %w", err)
 	}

--- a/internal/testkit/topology/chaos_soak_test.go
+++ b/internal/testkit/topology/chaos_soak_test.go
@@ -1,0 +1,277 @@
+package topology
+
+// Chaos soak with a RESTORE-PROOF gate (integrity program #1).
+//
+// Runs the production model continuously — an ENCRYPTED repo, a
+// continuous `wal stream`, concurrent scheduled backups, constant DB
+// churn — over a real 3-node Patroni cluster while injecting a
+// randomized fault sequence (switchovers, leader pauses ≈ GC stalls,
+// concurrent-backup bursts). The pass criterion is never "exit 0": at
+// the end EVERY committed backup must verify (--full) AND restore, the
+// WAL lineage must be gap-free, and exactly one shared-DEK object must
+// exist. This is the harness shape that would have caught both #31
+// (concurrent-writer DEK fork) and #34 (switchover hang) before users
+// did.
+//
+// Rules encoded from the post-mortems:
+//   - Processes are NEVER restarted unless restart IS the fault being
+//     injected (the L4 lesson: the old scenario modeled the systemd-
+//     restart workaround and masked #34). This soak keeps the streamer
+//     running across every fault.
+//   - The fault sequence is seeded and logged, so any failure is
+//     reproducible: PGHS_CHAOS_SEED=<seed> re-runs the same schedule.
+//
+// Opt-in (needs Docker + the Spilo image):
+//
+//	PGHS_CHAOS_BIN=/tmp/pghs PGHS_CHAOS_MINUTES=6 \
+//	    go test -run TestChaosSoak_RestoreProof -timeout 30m \
+//	    ./internal/testkit/topology/
+//
+// The nightly chaos-soak workflow runs this with a 45-minute budget.
+
+import (
+	"context"
+	"fmt"
+	"math/rand"
+	"os"
+	"os/exec"
+	"strconv"
+	"strings"
+	"syscall"
+	"testing"
+	"time"
+)
+
+func TestChaosSoak_RestoreProof(t *testing.T) {
+	bin := os.Getenv("PGHS_CHAOS_BIN")
+	if bin == "" {
+		t.Skip("set PGHS_CHAOS_BIN to the pg_hardstorage binary under test")
+	}
+	minutes := 6
+	if v := os.Getenv("PGHS_CHAOS_MINUTES"); v != "" {
+		if n, err := strconv.Atoi(v); err == nil && n > 0 {
+			minutes = n
+		}
+	}
+	seed := time.Now().UnixNano()
+	if v := os.Getenv("PGHS_CHAOS_SEED"); v != "" {
+		if n, err := strconv.ParseInt(v, 10, 64); err == nil {
+			seed = n
+		}
+	}
+	rng := rand.New(rand.NewSource(seed))
+	t.Logf("chaos soak: budget=%dm seed=%d (re-run with PGHS_CHAOS_SEED=%d)", minutes, seed, seed)
+
+	scratch, err := os.MkdirTemp("", "chaos-soak-")
+	if err != nil {
+		t.Fatal(err)
+	}
+	home := scratch + "/home"
+	repoDir := scratch + "/repo"
+	repoURL := "file://" + repoDir
+	if err := os.MkdirAll(home, 0o700); err != nil {
+		t.Fatal(err)
+	}
+
+	p := newPatroniLocalDocker()
+	ctx := context.Background()
+	t.Logf("bringing up 3-node Patroni cluster…")
+	if err := p.Up(ctx, UpOptions{PGVersion: "17"}); err != nil {
+		t.Fatalf("cluster up: %v", err)
+	}
+	defer p.Down(context.Background())
+
+	var hosts []string
+	for _, n := range p.nodes {
+		hosts = append(hosts, fmt.Sprintf("127.0.0.1:%d", n.pgPort))
+	}
+	dsn := fmt.Sprintf("postgres://postgres:%s@%s/postgres?target_session_attrs=primary&sslmode=disable",
+		patroniSuperPassword, strings.Join(hosts, ","))
+
+	env := append(os.Environ(), "HOME="+home)
+	runBin := func(timeout time.Duration, args ...string) (string, int) {
+		cctx, cancel := context.WithTimeout(ctx, timeout)
+		defer cancel()
+		cmd := exec.CommandContext(cctx, bin, args...)
+		cmd.Env = env
+		out, err := cmd.CombinedOutput()
+		code := 0
+		if ee, ok := err.(*exec.ExitError); ok {
+			code = ee.ExitCode()
+		} else if err != nil {
+			code = -1
+		}
+		return string(out), code
+	}
+
+	// ENCRYPTED repo + first backup + config via init --quick (the #31
+	// posture: local KEK, aes-256-gcm, shared DEK across writers).
+	if out, code := runBin(3*time.Minute, "init", "--quick",
+		"--pg-connection", dsn, "--repo", repoURL, "--encrypt"); code != 0 {
+		t.Fatalf("init --quick --encrypt failed (%d):\n%s", code, tail(out, 1500))
+	}
+	t.Logf("encrypted repo initialised at %s", repoURL)
+
+	// Continuous streamer — NEVER restarted (soak rule #1).
+	streamLog, _ := os.Create(scratch + "/stream.log")
+	stream := exec.Command(bin, "wal", "stream", "db1",
+		"--pg-connection", dsn, "--repo", repoURL, "-o", "text")
+	stream.Env = env
+	stream.Stdout, stream.Stderr = streamLog, streamLog
+	if err := stream.Start(); err != nil {
+		t.Fatalf("start streamer: %v", err)
+	}
+	streamerDone := make(chan error, 1)
+	go func() { streamerDone <- stream.Wait() }()
+	t.Logf("streamer pid=%d (continuous; restarts are forbidden)", stream.Process.Pid)
+
+	// Constant DB churn: full-page-image-heavy updates on the CURRENT
+	// leader (re-resolved every iteration so churn survives failovers).
+	churnCtx, stopChurn := context.WithCancel(ctx)
+	defer stopChurn()
+	go func() {
+		i := 0
+		for churnCtx.Err() == nil {
+			i++
+			leader := p.findLeaderName(churnCtx)
+			for _, n := range p.nodes {
+				out, err := exec.Command("docker", "exec", n.container, "hostname").CombinedOutput()
+				if err != nil || strings.TrimSpace(string(out)) != leader {
+					continue
+				}
+				sql := fmt.Sprintf("create table if not exists churn(id int primary key, pad text); insert into churn select g, repeat('x',300) from generate_series(%d,%d) g on conflict (id) do update set pad=repeat('y',300); checkpoint;", i*500, i*500+499)
+				_ = exec.CommandContext(churnCtx, "docker", "exec", n.container,
+					"psql", "-U", "postgres", "-h", "127.0.0.1", "-qc", sql).Run()
+			}
+			select {
+			case <-churnCtx.Done():
+			case <-time.After(2 * time.Second):
+			}
+		}
+	}()
+
+	// Fault rounds until the budget expires.
+	faults := []string{"none", "switchover", "pause_leader", "backup_burst"}
+	deadline := time.Now().Add(time.Duration(minutes) * time.Minute)
+	round := 0
+	var faultLog []string
+	for time.Now().Before(deadline) {
+		round++
+		fault := faults[rng.Intn(len(faults))]
+		faultLog = append(faultLog, fault)
+		t.Logf("round %d: fault=%s", round, fault)
+
+		switch fault {
+		case "switchover":
+			if leader := p.findLeaderName(ctx); leader != "" {
+				if err := p.switchover(ctx, leader); err != nil {
+					t.Logf("  switchover request failed (tolerated, cluster may be settling): %v", err)
+				}
+				// Wait for the demoted node to rejoin — with the #34 fix
+				// this happens without touching the streamer. A node that
+				// stays stuck would resurface the hang; the final health
+				// check below catches it.
+				time.Sleep(20 * time.Second)
+			}
+		case "pause_leader":
+			if leader := p.findLeaderName(ctx); leader != "" {
+				for _, n := range p.nodes {
+					out, err := exec.Command("docker", "exec", n.container, "hostname").CombinedOutput()
+					if err == nil && strings.TrimSpace(string(out)) == leader {
+						pauseFor := time.Duration(3+rng.Intn(5)) * time.Second
+						t.Logf("  pausing leader container %s for %s (GC-stall simulator)", n.container[:12], pauseFor)
+						_ = exec.Command("docker", "pause", n.container).Run()
+						time.Sleep(pauseFor)
+						_ = exec.Command("docker", "unpause", n.container).Run()
+					}
+				}
+			}
+		case "backup_burst":
+			// Two concurrent backups racing each other + the streamer —
+			// the exact #31 shape. One may lose the lease (exit 7): fine.
+			done := make(chan int, 2)
+			for i := 0; i < 2; i++ {
+				go func() {
+					_, code := runBin(4*time.Minute, "backup", "db1",
+						"--pg-connection", dsn, "--repo", repoURL)
+					done <- code
+				}()
+			}
+			<-done
+			<-done
+		}
+
+		// Every round also takes one scheduled-style backup.
+		if out, code := runBin(4*time.Minute, "backup", "db1",
+			"--pg-connection", dsn, "--repo", repoURL); code != 0 && code != 7 {
+			t.Fatalf("round %d: backup failed with unexpected code %d (7=lease-conflict is tolerated):\n%s", round, code, tail(out, 1200))
+		}
+		time.Sleep(time.Duration(3+rng.Intn(5)) * time.Second)
+	}
+	stopChurn()
+	t.Logf("fault schedule (%d rounds): %s", round, strings.Join(faultLog, ","))
+
+	// The streamer must still be ALIVE after every fault (a crash or a
+	// silent exit is a soak failure in itself).
+	select {
+	case err := <-streamerDone:
+		logs, _ := os.ReadFile(scratch + "/stream.log")
+		t.Fatalf("streamer exited mid-soak: %v\n--- stream log tail ---\n%s", err, tail(string(logs), 2500))
+	default:
+	}
+
+	// Graceful stop (single SIGINT — exercises the graceful-drain path).
+	_ = stream.Process.Signal(syscall.SIGINT)
+	select {
+	case <-streamerDone:
+	case <-time.After(30 * time.Second):
+		_ = stream.Process.Kill()
+		<-streamerDone
+	}
+
+	// ---- RESTORE-PROOF GATE -------------------------------------------
+	// 1. Exactly one shared-DEK object (the #31 invariant).
+	dekObjs, _ := os.ReadDir(repoDir + "/keys/shared-dek")
+	if len(dekObjs) != 1 {
+		t.Errorf("shared-DEK objects = %d, want exactly 1 (divergent DEKs = #31 class)", len(dekObjs))
+	}
+
+	// 2. Every committed backup must verify AND restore.
+	out, code := runBin(2*time.Minute, "list", "db1", "--repo", repoURL, "-o", "text")
+	if code != 0 {
+		t.Fatalf("list failed (%d):\n%s", code, out)
+	}
+	var ids []string
+	for _, line := range strings.Split(out, "\n") {
+		f := strings.Fields(line)
+		if len(f) > 0 && strings.HasPrefix(f[0], "db1.full.") {
+			ids = append(ids, f[0])
+		}
+	}
+	if len(ids) < 2 {
+		t.Fatalf("soak committed only %d backups — not a meaningful proof (list output:\n%s)", len(ids), out)
+	}
+	t.Logf("restore-proof gate: %d backups to verify + restore", len(ids))
+	for _, id := range ids {
+		if out, code := runBin(5*time.Minute, "verify", "db1", id, "--repo", repoURL, "--full"); code != 0 {
+			t.Errorf("PROOF FAILED: verify --full %s exited %d:\n%s", id, code, tail(out, 1200))
+			continue
+		}
+		target := scratch + "/restore-" + id[len(id)-4:]
+		if out, code := runBin(5*time.Minute, "restore", "db1", id, "--repo", repoURL,
+			"--target", target, "--verify=skip"); code != 0 {
+			t.Errorf("PROOF FAILED: restore %s exited %d:\n%s", id, code, tail(out, 1200))
+		}
+		_ = os.RemoveAll(target)
+	}
+
+	// 3. The WAL lineage must be gap-free (slot continuity survived
+	//    every switchover/pause without a streamer restart).
+	if out, code := runBin(2*time.Minute, "wal", "audit", "db1", "--repo", repoURL, "-o", "text"); code != 0 {
+		t.Errorf("PROOF FAILED: wal audit exited %d (gap or lineage fault):\n%s", code, tail(out, 1500))
+	}
+
+	if !t.Failed() {
+		t.Logf("✓ chaos soak passed: %d rounds, %d backups all verified+restored, WAL gap-free, single shared DEK (seed=%d)", round, len(ids), seed)
+	}
+}

--- a/man/man1/pg_hardstorage-doctor.1
+++ b/man/man1/pg_hardstorage-doctor.1
@@ -18,6 +18,10 @@ Reports resolved filesystem paths, configuration status, and health checks.
 
 .SH OPTIONS
 .PP
+\fB--drill-max-age\fP=168h0m0s
+	maximum age of the last SUCCESSFUL recovery drill before doctor escalates recovery.drill_stale (CRITICAL)
+
+.PP
 \fB--exit-on-issues\fP[=false]
 	exit with code 10 (ExitDoctorIssues) when the report contains issues at warning+ severity; useful for cron / k8s liveness probes
 

--- a/man/man1/pg_hardstorage-schedule.1
+++ b/man/man1/pg_hardstorage-schedule.1
@@ -37,7 +37,7 @@ deployments without a schedule configured.
 
 .PP
 \fB--task\fP="backup"
-	which task's schedule to inspect/modify: backup | rotate
+	which task's schedule to inspect/modify: backup | rotate | drill
 
 
 .SH OPTIONS INHERITED FROM PARENT COMMANDS

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -298,6 +298,7 @@ nav:
       - Scaling to large fleets: operations/scaling-large-fleets.md
       - Cost reporting: operations/cost-reporting.md
       - SLO as code: operations/slo-as-code.md
+      - Integrity testing: operations/integrity-testing.md
   - Compliance:
       - compliance/index.md
       - GDPR Art. 17 — crypto-shred: compliance/gdpr-art-17-crypto-shred.md


### PR DESCRIPTION
Implements items 1–3 of the integrity program — three layers that keep "backup that won't restore" in the class of bugs machines catch before operators do. New docs page: `docs/operations/integrity-testing.md`.

## 1. Chaos soak with a restore-proof gate
- `TestChaosSoak_RestoreProof` (opt-in via `PGHS_CHAOS_BIN`) + nightly `chaos-soak` workflow (45-min budget, `workflow_dispatch` with `minutes`/`seed` inputs).
- Production model: encrypted repo, continuous `wal stream` (restarts forbidden — the lesson from #34), constant churn, over a real 3-node Patroni cluster; seeded random faults: switchover, leader pause (GC-stall simulator), concurrent-backup bursts (the #31 shape).
- Pass is never "exit 0": every committed backup must `verify --full` AND restore, `wal audit` must be gap-free, exactly one shared-DEK object may exist, and the streamer must survive every fault and stop gracefully on one SIGINT. The seed is logged for deterministic replay.

## 2. Zero tolerated contract failures
- `ParallelPuts_SingleWinner` + `ParallelOverwrites_NoTornContent` are now **mandatory** in the storage contract suite. Capability-aware: honest `ConditionalPut=false` skips; claiming `true` and losing the race is red.
- scp backend now runs the full contract against a **real sshd** — which surfaced a production gap, fixed here: bounded session-open retry under `MaxSessions` backpressure.
- Callers degrade loudly on no-conditional-put backends: the backup runner emits a `lease_unenforceable` warning event; the audit chain read-back-verifies every slot it wins (regression test with a lying backend).
- New `storage-contract` CI job with `PG_HARDSTORAGE_DEMAND_DOCKER/SSHD=1` so fixtures can never silently skip.

## 3. Continuous restorability in production
- `schedule.drill` per deployment; the agent restores the latest backup into a scratch dir and sandbox-verifies it on that cadence, recording every verdict in the repo's drill history (`pg_hardstorage schedule db1 'daily_at 03:00' --task drill`).
- `doctor` drill-freshness checks: `recovery.drill_never_run` (notice), `recovery.drill_failing` (critical), `recovery.drill_stale` (critical, `--drill-max-age`, default 7d) + a `drills` report section for dashboards.

## Bugs found by the program while validating it
The **first soak run** flagged all 32 backups as corrupt (`pg_control: CRC is incorrect`) — a real bug, fixed here: `verify --full` and the agent's scheduled verify parsed the manifest's plain-major `pg_version` (17) as `PG_VERSION_NUM`, divided to 0, and ran **every** backup through the PG18 default sandbox, whose `pg_verifybackup` rejects a PG17 `pg_control`. Healthy backups were reported unrestorable; `recovery drill` (correct major resolution) passed the same backups, and that diff pinpointed it. Also fixed:
- agent drill tasks wire the keystore KEK/DEK resolvers (drills on encrypted repos failed instantly),
- `verify --full` failure results now carry the actual pg_verifybackup stderr (they pointed at a `tool_stdout` body field that error results don't have — and stderr, where the tool writes findings, was dropped),
- schedule fleet header counts distinct deployments instead of `rows/2`.

## Validation
- Chaos soak re-run post-fix: **PASS** — 23 rounds (5 switchovers, 8 leader pauses, 7 backup bursts), 31 backups all verified (`--full`, correct PG17 sandbox) + restored, WAL gap-free, single shared DEK (`seed=1784837198012100934`).
- scp full contract green ×5 under `-race` against a real host sshd; audit lying-backend regression green ×3.
- Drill E2E: doctor `drill_never_run` → drill pass → `fresh: true`; agent `every 1m` fired two drills, both `pass` with `restore_ok`/`verify_ok`.
- `-race` suites green: cli, agent, audit, backup/runner, config, storage/{fs,scp,contract}, recovery, verify/sandbox. Full `go build ./... && go vet ./...` clean.