### PR TITLE
fix: five corruption / backup-availability bugs from a targeted hunt

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,56 @@ keeps reading that version for at least 24 months after a successor lands.
 
 ## [Unreleased]
 
+### Corruption hunt: five fixes for silent data-corruption and backup-availability bugs
+
+A three-way audit of the write path, the WAL pipeline, and the
+encryption/agent layers found and fixed five bugs, each with a
+regression test:
+
+- **Agent-scheduled backups were silently unencrypted.** Neither the
+  agent's schedule engine nor the control-plane executor ever consulted
+  the keystore, so every scheduled backup wrote plaintext even in a repo
+  initialised with `--encrypt` — and plaintext-hash dedup then welded
+  plaintext and encrypted backups onto the same chunks (manifests
+  claiming aes-256-gcm referencing cleartext chunks, breaking the
+  crypto-shred guarantee; unencrypted manifests referencing GCM
+  envelopes they can never decrypt). Both paths now resolve encryption
+  exactly like the interactive CLI, and a corrupt KEK fails the backup
+  loudly instead of silently falling back to plaintext.
+- **One wedged task starved the agent's scheduler forever.** Tasks fire
+  serially with no deadline, so a single hung Run (wedged docker daemon
+  during a drill, D-state I/O during a backup) silently stopped every
+  scheduled backup on the agent while the process looked healthy. Every
+  task now runs under a wall-clock ceiling (per-task override, default
+  2× its own cadence clamped to [1h, 48h]); at the ceiling its context
+  is cancelled and — if it still won't return — the task is abandoned
+  with a loud error so the other tasks keep firing.
+- **`repo gc --apply` (and `repair chunks --orphans --apply`) could
+  delete chunks an in-flight backup had deduplicated against.** The
+  chunk-age floor only protects chunks a running backup *wrote*; chunks
+  it *deduplicated against* are old by definition, so a sweep could
+  reap them and a signed, committed backup would reference deleted
+  chunks. Both sweeps now refuse while any unexpired backup lease
+  exists (an unreadable lease refuses too — never "couldn't check,
+  deleting anyway") and re-collect references immediately before
+  deleting so backups committed since the first snapshot keep their
+  chunks. Dry-runs are unaffected.
+- **The WAL sink missed gaps that landed exactly on a segment
+  boundary.** Right after a segment hand-off there is no current
+  segment, so both per-segment guards went blind and a skip to a later
+  segment's first byte would commit past an unrecorded hole — PG then
+  recycles the missing WAL and the gap becomes permanent. The sink now
+  enforces strict stream-level contiguity: every record must start
+  exactly where the previous one ended.
+- **The streamer reported the apply LSN as the RAM-buffered receive
+  position.** Under `synchronous_commit=remote_apply` (reachable via
+  `--skip-preflight` or a post-start GUC change) the primary would ACK
+  commits whose WAL existed only in the streamer's volatile buffers —
+  acknowledged transactions lost if the host died. The standby status
+  update now reports apply = flush (the durably-synced position); the
+  fast-shutdown drain (issue #101) is unaffected because it only needs
+  the write field.
+
 ## [1.0.16] — 2026-07-24
 
 ### Integrity program: scheduled drills, contract enforcement, chaos soak

--- a/internal/agent/executor.go
+++ b/internal/agent/executor.go
@@ -12,6 +12,7 @@ import (
 	"github.com/cybertec-postgresql/pg_hardstorage/internal/backup/runner"
 	"github.com/cybertec-postgresql/pg_hardstorage/internal/config"
 	"github.com/cybertec-postgresql/pg_hardstorage/internal/output"
+	"github.com/cybertec-postgresql/pg_hardstorage/internal/paths"
 )
 
 // BackupExecutor implements JobExecutor for JobBackup. It wraps the
@@ -122,6 +123,19 @@ func (b *BackupExecutor) runBackup(ctx context.Context, job *ControlPlaneJob, pr
 		progress(body)
 	}
 
+	// Resolve encryption exactly like the interactive CLI: KEK on
+	// the keyring ⇒ encrypt. Without this, control-plane backups were
+	// silently plaintext even in an --encrypt repo, and plaintext-hash
+	// dedup welds those manifests onto encrypted chunks.
+	var enc *runner.EncryptionConfig
+	if p, perr := paths.Resolve(paths.DefaultOptions()); perr == nil {
+		var eerr error
+		enc, eerr = runner.LocalEncryptionFromKeyring(p.Keyring.Value)
+		if eerr != nil {
+			return nil, fmt.Errorf("backup-executor: %w", eerr)
+		}
+	}
+
 	res, err := runner.Take(ctx, runner.TakeOptions{
 		PGConnString:      dep.PGConnection,
 		RepoURL:           repoURL,
@@ -133,6 +147,7 @@ func (b *BackupExecutor) runBackup(ctx context.Context, job *ControlPlaneJob, pr
 		Fast:              fast,
 		InactivityTimeout: inactivity,
 		OnEvent:           emit,
+		Encryption:        enc,
 		// Actor in the audit chain: the dispatch path uses the
 		// agent-id-on-job, distinguishing scheduler-driven backups
 		// from operator-initiated ones.

--- a/internal/backup/runner/encryption_local.go
+++ b/internal/backup/runner/encryption_local.go
@@ -1,0 +1,32 @@
+package runner
+
+import (
+	"fmt"
+
+	"github.com/cybertec-postgresql/pg_hardstorage/internal/backup/keystore"
+)
+
+// LocalEncryptionFromKeyring mirrors the CLI's local-custody
+// auto-encryption decision for non-interactive callers (the agent's
+// schedule engine and the control-plane executor): when a KEK exists
+// at keyringDir the backup MUST encrypt with it; when none exists the
+// backup is plaintext, exactly like `pg_hardstorage backup` without
+// flags on the same host.
+//
+// This exists because the agent paths used to build TakeOptions with
+// no Encryption at all — every scheduled backup was silently
+// plaintext even in a repo initialised with --encrypt. Plaintext-hash
+// dedup then welds those manifests onto encrypted chunks (and vice
+// versa): manifests claiming aes-256-gcm can reference cleartext
+// chunks, breaking the crypto-shred guarantee, and unencrypted
+// manifests can reference GCM envelopes they can never decrypt.
+func LocalEncryptionFromKeyring(keyringDir string) (*EncryptionConfig, error) {
+	if !keystore.KEKExists(keyringDir) {
+		return nil, nil
+	}
+	kek, _, err := keystore.LoadOrGenerateKEK(keyringDir)
+	if err != nil {
+		return nil, fmt.Errorf("load KEK from keyring: %w", err)
+	}
+	return &EncryptionConfig{KEK: kek, KEKRef: keystore.KEKRefLocal}, nil
+}

--- a/internal/backup/runner/encryption_local_test.go
+++ b/internal/backup/runner/encryption_local_test.go
@@ -1,0 +1,61 @@
+package runner
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/cybertec-postgresql/pg_hardstorage/internal/backup/keystore"
+)
+
+// The agent's schedule engine and the control-plane executor resolve
+// encryption through this helper. Before it existed they built
+// TakeOptions with no Encryption at all — every scheduled backup was
+// silently plaintext in an --encrypt repo, and plaintext-hash dedup
+// then welded plaintext manifests onto encrypted chunks (crypto-shred
+// guarantee broken) and vice versa (restore failure).
+func TestLocalEncryptionFromKeyring(t *testing.T) {
+	t.Run("no_kek_means_plaintext", func(t *testing.T) {
+		cfg, err := LocalEncryptionFromKeyring(t.TempDir())
+		if err != nil {
+			t.Fatal(err)
+		}
+		if cfg != nil {
+			t.Fatalf("empty keyring: cfg = %+v, want nil", cfg)
+		}
+	})
+
+	t.Run("kek_present_means_encrypt", func(t *testing.T) {
+		dir := t.TempDir()
+		// Materialise a KEK the way init --encrypt does.
+		if _, generated, err := keystore.LoadOrGenerateKEK(dir); err != nil || !generated {
+			t.Fatalf("generate KEK: generated=%v err=%v", generated, err)
+		}
+		cfg, err := LocalEncryptionFromKeyring(dir)
+		if err != nil {
+			t.Fatal(err)
+		}
+		if cfg == nil {
+			t.Fatal("KEK present but helper chose plaintext — scheduled backups would silently not encrypt")
+		}
+		if cfg.KEKRef != keystore.KEKRefLocal {
+			t.Errorf("KEKRef = %q, want %q", cfg.KEKRef, keystore.KEKRefLocal)
+		}
+		var zero [32]byte
+		if cfg.KEK == zero {
+			t.Error("KEK is all-zero — keyring key was not actually loaded")
+		}
+	})
+
+	t.Run("corrupt_kek_is_an_error_not_plaintext", func(t *testing.T) {
+		dir := t.TempDir()
+		// A present-but-invalid KEK must fail the backup loudly, never
+		// silently fall back to plaintext.
+		if err := os.WriteFile(filepath.Join(dir, keystore.KEKFileName), []byte("short"), 0o600); err != nil {
+			t.Fatal(err)
+		}
+		if _, err := LocalEncryptionFromKeyring(dir); err == nil {
+			t.Fatal("corrupt KEK accepted (or silently ignored) — want an error")
+		}
+	})
+}

--- a/internal/cli/agent.go
+++ b/internal/cli/agent.go
@@ -537,6 +537,20 @@ func buildBackupTask(name string, dep config.DeploymentConfig, signer *backup.Si
 		Name:     "backup:" + name,
 		Schedule: sched,
 		Run: func(ctx context.Context) error {
+			// Resolve encryption exactly like the interactive CLI:
+			// KEK on the keyring ⇒ encrypt. Resolved per run (not at
+			// task build) so a KEK installed after agent start takes
+			// effect without a restart. Without this every scheduled
+			// backup was silently plaintext — and plaintext-hash dedup
+			// welds those manifests onto encrypted chunks.
+			var enc *runner.EncryptionConfig
+			if p, perr := paths.Resolve(paths.DefaultOptions()); perr == nil {
+				var eerr error
+				enc, eerr = runner.LocalEncryptionFromKeyring(p.Keyring.Value)
+				if eerr != nil {
+					return fmt.Errorf("agent backup %s: %w", name, eerr)
+				}
+			}
 			_, err := runner.Take(ctx, runner.TakeOptions{
 				PGConnString: dep.PGConnection,
 				RepoURL:      dep.Repo,
@@ -544,6 +558,7 @@ func buildBackupTask(name string, dep config.DeploymentConfig, signer *backup.Si
 				Tenant:       dep.Tenant,
 				Signer:       signer,
 				Verifier:     verifier,
+				Encryption:   enc,
 			})
 			return err
 		},

--- a/internal/cli/repair.go
+++ b/internal/cli/repair.go
@@ -888,9 +888,33 @@ func runRepairChunks(cmd *cobra.Command, repoURL string, orphans, apply bool, mi
 			body.Chunks = append(body.Chunks, h.String())
 		}
 		if apply {
+			// Same dedup-vs-GC guards as `repo gc --apply` (which see):
+			// the age floor cannot protect chunks an in-flight backup
+			// DEDUPLICATED against — those are old by definition — so
+			// refuse under a live backup lease, and re-collect
+			// references so a backup committed since the snapshot
+			// keeps its chunks.
+			if live, lerr := findLiveBackupLeases(cmd.Context(), sp, time.Now().UTC()); lerr != nil {
+				return output.NewError("repair.lease_scan_failed",
+					fmt.Sprintf("repair chunks: scan backup leases: %v", lerr)).Wrap(lerr)
+			} else if len(live) > 0 {
+				return output.NewError("repair.live_backup_lease",
+					fmt.Sprintf("repair chunks: refusing --apply while backups are in flight for: %s", strings.Join(live, ", "))).
+					WithSuggestion(&output.Suggestion{
+						Human: "an in-flight backup may have deduplicated against chunks this sweep would delete — re-run after the backups finish (a crashed holder's lease expires within its TTL, 15 minutes by default)",
+					})
+			}
+			refsAtDelete, rerr := repo.CollectReferences(cmd.Context(), sp)
+			if rerr != nil {
+				return output.NewError("repair.collect_refs_failed",
+					fmt.Sprintf("repair chunks: re-collect references before delete: %v", rerr)).Wrap(rerr)
+			}
 			cas := casdefault.New(sp)
 			deleted := 0
 			for _, h := range hashes {
+				if refsAtDelete.Has(h) {
+					continue // referenced by a manifest committed since the snapshot
+				}
 				if err := cas.DeleteChunk(cmd.Context(), h); err != nil {
 					return output.NewError("repair.delete_failed",
 						fmt.Sprintf("repair chunks: delete %s: %v", h, err)).Wrap(err)

--- a/internal/cli/repo_gc.go
+++ b/internal/cli/repo_gc.go
@@ -3,6 +3,8 @@ package cli
 
 import (
 	"context"
+	"encoding/json"
+	"errors"
 	"fmt"
 	"io"
 	"sort"
@@ -240,11 +242,48 @@ func runRepoGC(cmd *cobra.Command, repoURL string, apply bool, approvalID string
 	// emitted so a partial sweep still reports what it reclaimed.
 	var partialErr error
 	if apply {
+		// Live-lease guard (dedup-vs-GC race, part 1). The chunk-age
+		// floor only protects chunks an in-flight backup WROTE (young
+		// mtime); chunks it DEDUPLICATED against are old by definition
+		// — an orphan from a failed run yesterday whose content
+		// reappears in today's data gets a dedup hit that never
+		// touches the object. Deleting it here corrupts a backup that
+		// commits successfully minutes later. A live lease means such
+		// a backup may be in flight, so refuse; leases expire within
+		// their TTL (15 min default), so a crashed holder never blocks
+		// gc for long.
+		if live, lerr := findLiveBackupLeases(cmd.Context(), sp, time.Now().UTC()); lerr != nil {
+			return output.NewError("repo.gc.lease_scan_failed",
+				fmt.Sprintf("repo gc: scan backup leases: %v", lerr)).Wrap(lerr)
+		} else if len(live) > 0 {
+			return output.NewError("repo.gc.live_backup_lease",
+				fmt.Sprintf("repo gc: refusing --apply while backups are in flight for: %s", strings.Join(live, ", "))).
+				WithSuggestion(&output.Suggestion{
+					Human: "an in-flight backup may have deduplicated against chunks this sweep would delete — re-run after the backups finish (a crashed holder's lease expires within its TTL, 15 minutes by default)",
+				})
+		}
+
+		// Re-collect references (dedup-vs-GC race, part 2): the first
+		// snapshot may be minutes old by now, and a backup that
+		// committed since then can reference chunks the snapshot saw
+		// as orphans. Deletion decisions use the FRESH set.
+		refsAtDelete, rerr := repo.CollectReferencesWithOptions(cmd.Context(), sp,
+			repo.CollectReferencesOptions{TombstoneGrace: graceForCall})
+		if rerr != nil {
+			return output.NewError("repo.gc.collect_refs_failed",
+				fmt.Sprintf("repo gc: re-collect references before delete: %v", rerr)).Wrap(rerr)
+		}
+
 		cas := casdefault.New(sp)
 		var deleted int
 		var deletedBytes int64
 		var failures []string
 		for _, h := range hashes {
+			if refsAtDelete.Has(h) {
+				// Referenced by a manifest committed after the first
+				// snapshot — not an orphan anymore.
+				continue
+			}
 			// Stat-then-delete so a race-induced miss doesn't blow the
 			// whole sweep — we account only what we actually removed.
 			info, statErr := sp.Stat(cmd.Context(), repo.ChunkKey(h))
@@ -425,4 +464,51 @@ func (b repoGCBody) WriteText(w io.Writer) error {
 	}
 	_, err := io.WriteString(w, strings.TrimRight(bw.String(), "\n"))
 	return err
+}
+
+// findLiveBackupLeases scans leases/ for backup leases whose
+// ExpiresAt is still in the future and returns the deployments that
+// hold them. `repo gc --apply` refuses to sweep while any exist: an
+// in-flight backup may have deduplicated against exactly the old,
+// unreferenced chunks the sweep is about to delete, and neither the
+// chunk-age floor nor the reference snapshot can see that reuse.
+func findLiveBackupLeases(ctx context.Context, sp storage.StoragePlugin, now time.Time) ([]string, error) {
+	var live []string
+	for info, err := range sp.List(ctx, "leases/") {
+		if err != nil {
+			return nil, err
+		}
+		if !strings.HasSuffix(info.Key, "/backup.json") {
+			continue
+		}
+		rc, gerr := sp.Get(ctx, info.Key)
+		if gerr != nil {
+			if errors.Is(gerr, storage.ErrNotFound) {
+				continue // released between List and Get
+			}
+			return nil, gerr
+		}
+		var lease struct {
+			Deployment string    `json:"deployment"`
+			ExpiresAt  time.Time `json:"expires_at"`
+		}
+		derr := json.NewDecoder(io.LimitReader(rc, 1<<20)).Decode(&lease)
+		_ = rc.Close()
+		if derr != nil {
+			// An unreadable lease is treated as LIVE, not ignored:
+			// gc deleting chunks because it couldn't parse the very
+			// object that says "backup in flight" is the wrong
+			// failure direction.
+			return nil, fmt.Errorf("parse lease %s: %w", info.Key, derr)
+		}
+		if now.Before(lease.ExpiresAt) {
+			name := lease.Deployment
+			if name == "" {
+				name = strings.TrimSuffix(strings.TrimPrefix(info.Key, "leases/"), "/backup.json")
+			}
+			live = append(live, name)
+		}
+	}
+	sort.Strings(live)
+	return live, nil
 }

--- a/internal/cli/repo_gc_lease_test.go
+++ b/internal/cli/repo_gc_lease_test.go
@@ -1,0 +1,80 @@
+package cli_test
+
+import (
+	"context"
+	"fmt"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/cybertec-postgresql/pg_hardstorage/internal/repo"
+)
+
+// The dedup-vs-GC race: `repo gc --apply`'s chunk-age floor only
+// protects chunks an in-flight backup WROTE (young mtime). Chunks the
+// backup DEDUPLICATED against are old by definition — an aged orphan
+// whose content reappears gets a dedup hit that never touches the
+// object, and the sweep would delete it out from under a backup that
+// commits minutes later: a signed, "verified" manifest referencing a
+// chunk that no longer exists. The guard: --apply refuses while any
+// unexpired backup lease exists.
+func TestRepoGC_RefusesWhileBackupLeaseLive(t *testing.T) {
+	dir := configDir(t)
+	_ = dir
+
+	repoDir := t.TempDir()
+	repoURL := "file://" + repoDir
+	if _, err := repo.Init(context.Background(), repo.InitOptions{URL: repoURL}); err != nil {
+		t.Fatal(err)
+	}
+
+	writeLease := func(deployment string, expires time.Time) {
+		t.Helper()
+		leaseDir := filepath.Join(repoDir, "leases", deployment)
+		if err := os.MkdirAll(leaseDir, 0o755); err != nil {
+			t.Fatal(err)
+		}
+		body := fmt.Sprintf(`{"schema":"pg_hardstorage.lease.v1","deployment":%q,"owner":"host/pid-1","acquired_at":%q,"expires_at":%q}`,
+			deployment, time.Now().UTC().Add(-time.Minute).Format(time.RFC3339Nano),
+			expires.UTC().Format(time.RFC3339Nano))
+		if err := os.WriteFile(filepath.Join(leaseDir, "backup.json"), []byte(body), 0o644); err != nil {
+			t.Fatal(err)
+		}
+	}
+
+	// Live lease → --apply must refuse with the structured code.
+	writeLease("db1", time.Now().Add(10*time.Minute))
+	stdout, stderr, exit := runCmd(t, "repo", "gc", repoURL, "--apply", "--output", "json")
+	if exit == 0 {
+		t.Fatalf("gc --apply succeeded under a live backup lease:\n%s", stdout)
+	}
+	combined := stdout + stderr
+	if !strings.Contains(combined, "repo.gc.live_backup_lease") || !strings.Contains(combined, "db1") {
+		t.Errorf("want repo.gc.live_backup_lease naming db1; got:\n%s", combined)
+	}
+
+	// Dry-run is read-only and must NOT be blocked by the lease.
+	_, _, exit = runCmd(t, "repo", "gc", repoURL, "--output", "json")
+	if exit != 0 {
+		t.Errorf("dry-run refused under a live lease — it deletes nothing and must not be blocked (exit %d)", exit)
+	}
+
+	// Expired lease (crashed holder) → sweep proceeds.
+	writeLease("db1", time.Now().Add(-time.Minute))
+	stdout, stderr, exit = runCmd(t, "repo", "gc", repoURL, "--apply", "--output", "json")
+	if exit != 0 {
+		t.Errorf("gc --apply blocked by an EXPIRED lease (exit %d):\n%s%s", exit, stdout, stderr)
+	}
+
+	// Unparseable lease → refuse loudly (never "couldn't read the
+	// object that says a backup is in flight, deleting anyway").
+	if err := os.WriteFile(filepath.Join(repoDir, "leases", "db1", "backup.json"), []byte("{not json"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	stdout, stderr, exit = runCmd(t, "repo", "gc", repoURL, "--apply", "--output", "json")
+	if exit == 0 {
+		t.Errorf("gc --apply proceeded past an unreadable lease:\n%s%s", stdout, stderr)
+	}
+}

--- a/internal/pg/replication/stream.go
+++ b/internal/pg/replication/stream.go
@@ -381,7 +381,14 @@ func buildStatusUpdate(write, flush pglogrepl.LSN) ([]byte, error) {
 	out = append(out, standbyStatusUpdateByteID)
 	out = appendUint64BE(out, uint64(write)) // write LSN
 	out = appendUint64BE(out, uint64(flush)) // flush LSN
-	out = appendUint64BE(out, uint64(write)) // apply LSN (caught-up)
+	// apply MUST track flush, never write. An archiver "applies"
+	// nothing, and inflating apply to the RAM-buffered receive
+	// position would let a primary running synchronous_commit=
+	// remote_apply ACK commits whose WAL exists only in our volatile
+	// buffers — acknowledged transactions lost if this host dies.
+	// The shutdown-drain path (issue #101) only needs Max(write,
+	// flush), which the write field above already satisfies.
+	out = appendUint64BE(out, uint64(flush)) // apply LSN (= durable)
 	// PG epoch for timestamps is 2000-01-01 UTC; microseconds since.
 	now := time.Now().UTC()
 	pgEpoch := time.Date(2000, 1, 1, 0, 0, 0, 0, time.UTC)

--- a/internal/pg/replication/stream_test.go
+++ b/internal/pg/replication/stream_test.go
@@ -295,8 +295,11 @@ func TestBuildStatusUpdate_Shape(t *testing.T) {
 	if got := be64(body[9:17]); got != uint64(flush) {
 		t.Errorf("flush LSN = %x, want %x", got, uint64(flush))
 	}
-	if got := be64(body[17:25]); got != uint64(write) {
-		t.Errorf("apply LSN = %x, want %x (write)", got, uint64(write))
+	// apply must equal FLUSH, never write: inflating apply to the
+	// RAM-buffered receive position would let synchronous_commit=
+	// remote_apply ACK commits whose WAL is not durable anywhere.
+	if got := be64(body[17:25]); got != uint64(flush) {
+		t.Errorf("apply LSN = %x, want %x (flush — apply must never exceed the durable position)", got, uint64(flush))
 	}
 }
 

--- a/internal/pg/walsink/gap_boundary_test.go
+++ b/internal/pg/walsink/gap_boundary_test.go
@@ -1,0 +1,78 @@
+package walsink_test
+
+import (
+	"context"
+	"strings"
+	"testing"
+
+	"github.com/jackc/pglogrepl"
+
+	"github.com/cybertec-postgresql/pg_hardstorage/internal/pg/replication"
+	"github.com/cybertec-postgresql/pg_hardstorage/internal/pg/walsink"
+)
+
+// A WAL skip that lands EXACTLY on a segment boundary used to commit
+// silently: right after a hand-off there is no current segment, so
+// the per-segment guards (segNum mismatch, offset mismatch) never
+// ran, the sink adopted the later segment verbatim, and SyncedLSN
+// advanced past an unrecorded hole — PG then recycles the missing
+// WAL and the gap becomes permanent and unhealable. The stream-level
+// expectedNext check must refuse ANY record that does not start
+// exactly where the previous one ended.
+func TestSink_GapOnSegmentBoundary_Refused(t *testing.T) {
+	s, sp := newTestSink(t)
+
+	// Fill segment 0 exactly.
+	if err := s.OnRecord(context.Background(), replication.XLogRecord{
+		WALStart: pglogrepl.LSN(0),
+		Data:     fillBytes(0x21, walsink.SegmentSize),
+	}); err != nil {
+		t.Fatalf("segment 0: %v", err)
+	}
+
+	// Next record skips segment 1 entirely and starts at segment 2's
+	// first byte — boundary-aligned, so both legacy guards are blind.
+	err := s.OnRecord(context.Background(), replication.XLogRecord{
+		WALStart: pglogrepl.LSN(2 * walsink.SegmentSize),
+		Data:     fillBytes(0x22, walsink.SegmentSize),
+	})
+	if err == nil {
+		t.Fatal("boundary-aligned WAL skip was accepted — segment 2 would commit past an unrecorded hole")
+	}
+	if !strings.Contains(err.Error(), "gap detected") {
+		t.Errorf("error = %v, want a walsink gap refusal", err)
+	}
+
+	// The skipped-past segment must never have been committed.
+	if err := s.Flush(context.Background()); err != nil {
+		t.Logf("flush after refused record (best-effort): %v", err)
+	}
+	if _, err := sp.Get(context.Background(),
+		"wal/db1/00000001/000000010000000000000002.json"); err == nil {
+		t.Error("segment 2 manifest exists — a segment past the hole was committed")
+	}
+	if got := uint64(s.SyncedLSN()); got > walsink.SegmentSize {
+		t.Errorf("SyncedLSN = %x advanced past the hole (max allowed %x)", got, walsink.SegmentSize)
+	}
+}
+
+// Mid-segment gaps must also refuse via the same stream-level check
+// (previously caught by the offset guard — pinned here so the new
+// check demonstrably subsumes it).
+func TestSink_GapMidSegment_Refused(t *testing.T) {
+	s, _ := newTestSink(t)
+
+	if err := s.OnRecord(context.Background(), replication.XLogRecord{
+		WALStart: pglogrepl.LSN(0),
+		Data:     fillBytes(0x31, 4096),
+	}); err != nil {
+		t.Fatalf("first record: %v", err)
+	}
+	err := s.OnRecord(context.Background(), replication.XLogRecord{
+		WALStart: pglogrepl.LSN(8192), // 4 KiB hole inside segment 0
+		Data:     fillBytes(0x32, 4096),
+	})
+	if err == nil || !strings.Contains(err.Error(), "gap detected") {
+		t.Fatalf("mid-segment skip: err = %v, want gap refusal", err)
+	}
+}

--- a/internal/pg/walsink/walsink.go
+++ b/internal/pg/walsink/walsink.go
@@ -211,6 +211,16 @@ type Sink struct {
 	curStartLSN pglogrepl.LSN
 	haveSeg     bool
 
+	// expectedNext is the absolute WAL position the next record MUST
+	// start at (end of the last buffered byte). Zero until the first
+	// record arrives. Physical replication delivers strictly
+	// contiguous bytes, so any jump is an upstream fault — this check
+	// subsumes the per-segment guards below, which both go blind when
+	// a skip lands exactly on a segment boundary (haveSeg is false
+	// right after a hand-off, so the segNum/offset checks never run
+	// and a hole-spanning segment would commit silently).
+	expectedNext uint64
+
 	// Pipeline plumbing.
 	bufPool  chan []byte   // free 16 MiB segment buffers
 	pending  chan *segJob  // filled segments handed receive -> processor
@@ -461,6 +471,17 @@ func (s *Sink) OnRecord(ctx context.Context, rec replication.XLogRecord) error {
 	pos := uint64(rec.WALStart)
 	data := rec.Data
 
+	// Strict contiguity at the stream level: after the first record,
+	// every record must start exactly where the previous one ended.
+	// The in-loop segment/offset guards cannot catch a skip that
+	// lands on a segment boundary (no current segment right after a
+	// hand-off), which would otherwise commit a segment past an
+	// unrecorded hole and let PG recycle the missing WAL for good.
+	if s.expectedNext != 0 && pos != s.expectedNext {
+		return fmt.Errorf("walsink: gap detected: expected next WAL byte at %s, got record starting at %s",
+			pglogrepl.LSN(s.expectedNext), rec.WALStart)
+	}
+
 	for len(data) > 0 {
 		segSize := uint64(s.segSize)
 		segNum := pos / segSize
@@ -503,6 +524,7 @@ func (s *Sink) OnRecord(ctx context.Context, rec replication.XLogRecord) error {
 		// Publish the new receive frontier for diagnostic readers
 		// (BufferedLSN).  Monotonic because the loop only advances pos.
 		s.bufferedLSN.Store(pos)
+		s.expectedNext = pos
 
 		if s.curFilled == int(s.segSize) {
 			if err := s.handOff(ctx); err != nil {

--- a/internal/pg/walsink/walsink_test.go
+++ b/internal/pg/walsink/walsink_test.go
@@ -257,8 +257,11 @@ func TestSink_OutOfOrderOffset_Rejected(t *testing.T) {
 	if err == nil {
 		t.Fatal("expected error on non-sequential WAL")
 	}
-	if !strings.Contains(err.Error(), "out-of-order") {
-		t.Errorf("error should mention out-of-order; got %v", err)
+	// The stream-level contiguity check now refuses this before the
+	// per-segment offset guard is reached; either refusal message is
+	// fine as long as the record is rejected.
+	if !strings.Contains(err.Error(), "out-of-order") && !strings.Contains(err.Error(), "gap detected") {
+		t.Errorf("error should mention out-of-order or gap; got %v", err)
 	}
 }
 

--- a/internal/schedule/engine.go
+++ b/internal/schedule/engine.go
@@ -23,6 +23,17 @@ type Task struct {
 	// Run is what the task does. Errors are reported but do not
 	// stop the engine. Run must respect ctx.
 	Run func(ctx context.Context) error
+
+	// Timeout bounds one execution of Run. Zero means the engine
+	// derives a default from the task's own cadence (twice the
+	// schedule interval, clamped to [1h, 48h]). When the deadline
+	// passes, the engine cancels Run's ctx and — crucially — moves
+	// on even if Run never returns: tasks fire serially, so a
+	// single wedged Run (hung docker daemon, D-state I/O) would
+	// otherwise stop EVERY scheduled task on the agent forever,
+	// silently. An abandoned Run keeps its goroutine until it
+	// honors the cancelled ctx; its eventual result is discarded.
+	Timeout time.Duration
 }
 
 // Engine is the scheduler runtime. It walks Tasks, sleeps until the
@@ -279,7 +290,7 @@ func (e *Engine) runOne(ctx context.Context, st *scheduledTask, dueAt time.Time)
 		e.onStart(st.t.Name, dueAt)
 	}
 	start := e.clock.Now()
-	err := safeRun(ctx, st.t.Run)
+	err := e.runBounded(ctx, st)
 	dur := e.clock.Now().Sub(start)
 	if e.onFinish != nil {
 		e.onFinish(st.t.Name, dueAt, dur, err)
@@ -312,6 +323,82 @@ func (e *Engine) runOne(ctx context.Context, st *scheduledTask, dueAt time.Time)
 	st.lastErr = err
 	st.nextDue = next
 	e.mu.Unlock()
+}
+
+// runBounded executes the task's Run with a wall-clock ceiling. The
+// task runs on its own goroutine; when the ceiling passes, Run's ctx
+// is cancelled and runBounded returns a timeout error WITHOUT waiting
+// for Run — the engine's serial loop must never be held hostage by
+// one wedged task (a hung docker daemon or D-state I/O would
+// otherwise silently stop every scheduled backup on this agent,
+// forever, while the process looks healthy). A well-behaved Run sees
+// the cancellation and exits; a truly wedged one is abandoned and its
+// eventual result discarded (done is buffered so it never blocks).
+func (e *Engine) runBounded(ctx context.Context, st *scheduledTask) error {
+	timeout := st.t.Timeout
+	if timeout <= 0 {
+		timeout = defaultTaskTimeout(st.t.Schedule, e.clock.Now())
+	}
+	// gracePeriod is real time (not e.clock): it exists to let an
+	// already-cancelled Run deliver its own error, which is a
+	// runtime property, not schedule time.
+	const gracePeriod = 5 * time.Second
+
+	tctx, cancel := context.WithCancel(ctx)
+	defer cancel()
+
+	done := make(chan error, 1)
+	go func() { done <- safeRun(tctx, st.t.Run) }()
+
+	select {
+	case err := <-done:
+		return err
+	case <-e.clock.After(timeout):
+		cancel()
+		// Give a ctx-respecting Run a short grace to surface its own
+		// (usually more informative) error before we abandon it.
+		select {
+		case err := <-done:
+			return err
+		case <-time.After(gracePeriod):
+			return fmt.Errorf("schedule: task %q exceeded its %s run ceiling and did not stop on cancel — abandoned so other tasks keep firing", st.t.Name, timeout)
+		}
+	case <-ctx.Done():
+		cancel()
+		select {
+		case err := <-done:
+			return err
+		case <-time.After(gracePeriod):
+			return ctx.Err()
+		}
+	}
+}
+
+// defaultTaskTimeout derives a run ceiling from the task's own
+// cadence: twice the schedule interval, clamped to [1h, 48h]. A
+// schedule whose interval can't be derived (one-shots) gets the 48h
+// ceiling — generous for any real backup, but finite.
+func defaultTaskTimeout(s Schedule, now time.Time) time.Duration {
+	const (
+		floor   = 1 * time.Hour
+		ceiling = 48 * time.Hour
+	)
+	n1 := s.Next(now)
+	if n1.IsZero() {
+		return ceiling
+	}
+	n2 := s.Next(n1)
+	if n2.IsZero() || !n2.After(n1) {
+		return ceiling
+	}
+	d := 2 * n2.Sub(n1)
+	if d < floor {
+		return floor
+	}
+	if d > ceiling {
+		return ceiling
+	}
+	return d
 }
 
 // safeRun runs fn under a panic-recovery shim so the engine survives

--- a/internal/schedule/starvation_test.go
+++ b/internal/schedule/starvation_test.go
@@ -1,0 +1,154 @@
+package schedule_test
+
+import (
+	"context"
+	"strings"
+	"sync"
+	"testing"
+	"time"
+
+	"github.com/cybertec-postgresql/pg_hardstorage/internal/schedule"
+)
+
+// The engine fires tasks serially with NO deadline of any kind: one
+// wedged Run (hung docker daemon during a drill, D-state I/O during a
+// backup) used to stop every other scheduled task on the agent
+// forever, while the process stayed alive and looked healthy. These
+// tests pin the run-ceiling behaviour: a task that overruns its
+// ceiling is cancelled (and, if it ignores the cancel, abandoned) and
+// the OTHER tasks keep firing.
+
+// finishRecorder collects onFinish callbacks thread-safely.
+type finishRecorder struct {
+	mu   sync.Mutex
+	errs map[string][]error
+}
+
+func newFinishRecorder() *finishRecorder {
+	return &finishRecorder{errs: make(map[string][]error)}
+}
+
+func (r *finishRecorder) record(name string, _ time.Time, _ time.Duration, err error) {
+	r.mu.Lock()
+	defer r.mu.Unlock()
+	r.errs[name] = append(r.errs[name], err)
+}
+
+func (r *finishRecorder) count(name string) int {
+	r.mu.Lock()
+	defer r.mu.Unlock()
+	return len(r.errs[name])
+}
+
+func (r *finishRecorder) firstErr(name string) error {
+	r.mu.Lock()
+	defer r.mu.Unlock()
+	if len(r.errs[name]) == 0 {
+		return nil
+	}
+	return r.errs[name][0]
+}
+
+// driveUntil advances the fake clock in a background loop until cond
+// holds or the real-time deadline passes. Over-advancing is safe: the
+// fake clock's After channels are buffered and fire on every advance.
+func driveUntil(t *testing.T, clock *fakeClock, cond func() bool, within time.Duration) {
+	t.Helper()
+	deadline := time.Now().Add(within)
+	for time.Now().Before(deadline) {
+		if cond() {
+			return
+		}
+		clock.advance(time.Hour)
+		time.Sleep(5 * time.Millisecond)
+	}
+	t.Fatalf("condition not reached within %s", within)
+}
+
+// A well-behaved but never-returning task (blocks on ctx) must be
+// cancelled at its run ceiling so later tasks fire.
+func TestEngine_WedgedTaskDoesNotStarveOthers(t *testing.T) {
+	clock := &fakeClock{now: time.Date(2026, 4, 28, 12, 0, 0, 0, time.UTC)}
+	rec := newFinishRecorder()
+	e := schedule.New(schedule.WithClock(clock), schedule.WithOnFinish(rec.record))
+
+	wedged, _ := schedule.Parse(schedule.Spec{Every: "1h"})
+	if err := e.Add(&schedule.Task{
+		Name:     "drill:wedged",
+		Schedule: wedged,
+		Run: func(ctx context.Context) error {
+			<-ctx.Done() // honors cancel, but would otherwise block forever
+			return ctx.Err()
+		},
+	}); err != nil {
+		t.Fatal(err)
+	}
+	healthy, _ := schedule.Parse(schedule.Spec{Every: "2h"})
+	if err := e.Add(&schedule.Task{
+		Name:     "backup:db1",
+		Schedule: healthy,
+		Run:      func(ctx context.Context) error { return nil },
+	}); err != nil {
+		t.Fatal(err)
+	}
+
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+	engDone := make(chan struct{})
+	go func() { _ = e.Run(ctx); close(engDone) }()
+
+	driveUntil(t, clock, func() bool { return rec.count("backup:db1") >= 1 }, 15*time.Second)
+
+	if got := rec.firstErr("drill:wedged"); got == nil {
+		t.Error("wedged task finished nil — expected a cancellation/ceiling error")
+	}
+	cancel()
+	<-engDone
+}
+
+// A task that IGNORES cancellation entirely must be abandoned after
+// the grace period — the engine's serial loop moves on regardless.
+func TestEngine_CancelIgnoringTaskIsAbandoned(t *testing.T) {
+	clock := &fakeClock{now: time.Date(2026, 4, 28, 12, 0, 0, 0, time.UTC)}
+	rec := newFinishRecorder()
+	e := schedule.New(schedule.WithClock(clock), schedule.WithOnFinish(rec.record))
+
+	hang := make(chan struct{}) // never closed
+	wedged, _ := schedule.Parse(schedule.Spec{Every: "1h"})
+	if err := e.Add(&schedule.Task{
+		Name:     "drill:stuck",
+		Schedule: wedged,
+		Timeout:  time.Minute,
+		Run: func(ctx context.Context) error {
+			<-hang // D-state simulator: ctx is ignored
+			return nil
+		},
+	}); err != nil {
+		t.Fatal(err)
+	}
+	healthy, _ := schedule.Parse(schedule.Spec{Every: "2h"})
+	if err := e.Add(&schedule.Task{
+		Name:     "backup:db1",
+		Schedule: healthy,
+		Run:      func(ctx context.Context) error { return nil },
+	}); err != nil {
+		t.Fatal(err)
+	}
+
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+	engDone := make(chan struct{})
+	go func() { _ = e.Run(ctx); close(engDone) }()
+
+	// The abandonment path includes a 5 s real-time grace, so allow
+	// generous real time here.
+	driveUntil(t, clock, func() bool { return rec.count("backup:db1") >= 1 }, 30*time.Second)
+
+	err := rec.firstErr("drill:stuck")
+	if err == nil || !strings.Contains(err.Error(), "abandoned") {
+		t.Errorf("stuck task error = %v, want the run-ceiling abandonment error", err)
+	}
+	cancel()
+	<-engDone
+	close(hang) // release the leaked goroutine for -race hygiene
+}


### PR DESCRIPTION
A three-hunter audit (write path + GC, WAL pipeline, encryption/agent) surfaced 12 evidenced findings; this PR fixes the five strongest. Each fix carries a regression test; all touched suites are green under `-race`.

| # | Bug | Class | Fix |
|---|-----|-------|-----|
| 1 | **Agent-scheduled + control-plane backups silently unencrypted** — neither path consulted the keystore, so scheduled backups wrote plaintext in `--encrypt` repos; plaintext-hash dedup then welded plaintext and encrypted backups onto the same chunks (crypto-shred guarantee broken one way, undecryptable restore the other) | Corruption | Both paths resolve encryption via new `runner.LocalEncryptionFromKeyring` (same semantics as the CLI); corrupt KEK = loud failure, never silent plaintext |
| 2 | **One wedged task starves the scheduler forever** — serial task execution with no deadline; a hung dockerd/D-state Run stopped every scheduled backup while the agent looked healthy | Availability | Per-task wall-clock ceiling (override via `Task.Timeout`, default 2× cadence clamped to [1h, 48h]); ctx-cancelled at the ceiling, abandoned with a loud error if it won't stop |
| 3 | **`repo gc --apply` / `repair chunks --orphans --apply` delete chunks an in-flight backup deduplicated against** — the age floor only protects freshly-written chunks; dedup targets are old by definition | Corruption | Refuse under any unexpired backup lease (unreadable lease also refuses); references re-collected immediately before the delete loop; dry-runs unaffected |
| 4 | **walsink misses WAL gaps landing exactly on a segment boundary** — right after a hand-off both per-segment guards are blind; a hole-spanning segment committed and PG recycled the missing WAL | Corruption | Strict stream-level contiguity: every record must start exactly where the previous ended (subsumes both old guards) |
| 5 | **Streamer reports apply LSN = RAM-buffered receive position** — `synchronous_commit=remote_apply` could ACK commits whose WAL wasn't durable anywhere | Durability | Standby status updates report apply = flush; issue-#101 fast-shutdown drain unaffected (it only needs the write field) |

Remaining findings from the hunt are documented as backlog (timeline-history archival in plain `wal stream`, backup WAL-range coverage validation, local KEK-rotation brick, `verify --full` fabricated skip, sftp/scp durability-capability warning, `.deferred-*` staging leak, shared-DEK nonce budget).