### PR TITLE
fix: eight more corruption / backup-availability bugs (hunt round 2)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,69 @@ keeps reading that version for at least 24 months after a successor lands.
 
 ## [Unreleased]
 
+### Corruption hunt, round two: eight more fixes
+
+A second audit round (restore/rotate/tarsink, S3/init/manifest, plus
+the backlog from round one) fixed eight more corruption and
+backup-availability bugs, each with a regression test:
+
+- **KEK rotation could permanently destroy backups.** The manifest
+  rewrite was Put-tmp → DELETE original → rename, and a rename failure
+  "cleaned up" by deleting the tmp — destroying the only copy at the
+  primary key; the backup vanished from every listing AND from GC's
+  reference walk, so the next sweep reaped its chunks. The rewrite is
+  now a single atomic overwrite: a valid manifest body exists at the
+  key at every instant.
+- **KEK rotation bricked all future backups and made rotated backups
+  unrestorable.** Rotation rewrapped manifests but left the
+  authoritative shared-DEK object under the retired KEK (every
+  subsequent backup and `wal stream` then hard-failed), and the
+  rotated manifests' new `local:v2`-style KEKRef was rejected by every
+  shipped resolver. Rotation now migrates the shared-DEK object (same
+  DEK, new wrap) including the fixed `local:default` alias the
+  CLI/agent stamp; `ResolveOrMint` falls through to the manifest scan
+  when the object won't unwrap; and both resolvers route any `local:*`
+  ref to the keyring.
+- **`backup undelete` could resurrect an incremental whose parent
+  chain stayed tombstoned** — a live-listing backup every restore
+  refuses, hardening into permanent loss once GC grace expired. The
+  chain is now walked and the first dead ancestor named.
+- **`repo.Open`'s forward-format gate failed OPEN on transient read
+  errors** of `_repo_version.json` (throttle, partition, IAM deny were
+  treated like "marker absent = v1.0"), letting an old binary mutate a
+  future-format repo whose manifests it skips as "malformed" — and GC
+  would reap chunks those manifests reference. Now fail-closed; only a
+  definitive not-found takes the legacy path.
+- **`Manifest.Validate` accepted structurally unrestorable chain
+  shapes**: an incremental with no (or a self-referential) parent
+  committed green, skipped the parent-liveness and chain-protection
+  guards, and failed only at restore. Validate now enforces
+  type/parent/timeline invariants at the same gate that already
+  refuses undecryptable encryption shapes.
+- **The S3 plugin claimed `ConditionalPut: true` for every endpoint.**
+  On S3-compatible endpoints the claim was a guess — and it disables
+  the exact mitigations built for honest-false backends (audit-chain
+  read-back, lease warning). Custom `?endpoint=` overrides now report
+  false unless the operator vouches with `?conditional_put=native`
+  (MinIO ≥ 2024, R2); AWS proper stays true.
+- **`verify --full` fabricated "skipped" out of environment
+  failures**: a sandbox that couldn't see the freshly-written
+  `backup_manifest` (bad bind-mount, remote DOCKER_HOST, permissions)
+  was classified as "manifest was not captured" and exited 0. When the
+  caller captured a manifest, that stderr is now a real failure.
+- **Backends with no enforceable durability (sftp/scp) were silent.**
+  The backup runner now emits `backup`/`durability_unenforceable` and
+  `wal stream` emits `wal.durability`/`unenforceable` when a backend
+  has neither a real barrier nor inline-durable writes — a
+  storage-host power loss there can tear chunks under a committed
+  manifest or lose WAL the slot has advanced past.
+
+Documented, not yet fixed (next round): timeline-history archival in
+plain `wal stream`, backup WAL-range coverage validation, restore
+resume re-validation after host crash, legal-hold chain-aware
+retention filtering, type-aware capacity projection, `.deferred-*`
+staging reaper, shared-DEK nonce budget.
+
 ### Corruption hunt: five fixes for silent data-corruption and backup-availability bugs
 
 A three-way audit of the write path, the WAL pipeline, and the

--- a/internal/agent/verify_executor.go
+++ b/internal/agent/verify_executor.go
@@ -181,6 +181,10 @@ func (e *VerifyExecutor) Execute(ctx context.Context, job *ControlPlaneJob, prog
 	res, err := sandbox.Verify(ctx, sandbox.Options{
 		DataDir: tmp,
 		PGMajor: major,
+		// The restore above writes backup_manifest whenever the
+		// manifest carries it — so a "could not open backup_manifest"
+		// from pg_verifybackup is an environment fault, not a skip.
+		ManifestCaptured: len(m.PGBackupManifest) > 0,
 	})
 	if err != nil {
 		// The sandbox itself failed to run (Docker unreachable, image

--- a/internal/backup/keystore/kek.go
+++ b/internal/backup/keystore/kek.go
@@ -8,6 +8,7 @@ import (
 	"io/fs"
 	"os"
 	"path/filepath"
+	"strings"
 
 	"github.com/cybertec-postgresql/pg_hardstorage/internal/plugin/encryption"
 )
@@ -202,6 +203,16 @@ var ErrKEKAlreadyShred = errors.New("keystore: KEK already shred (no kek.bin in 
 func KEKResolver(keyringDir string) func(ref string) ([encryption.KeyLen]byte, error) {
 	return func(ref string) ([encryption.KeyLen]byte, error) {
 		var zero [encryption.KeyLen]byte
+		// Any local:* ref resolves to the keyring file: `kms rotate`
+		// refuses old==new refs, so a local rotation necessarily
+		// stamps a NEW local ref (e.g. "local:v2") on every rotated
+		// manifest — and the operator's keyring holds the matching
+		// key material. Restricting this resolver to exactly
+		// "local:default" made every rotated backup unrestorable by
+		// any shipped code path.
+		if strings.HasPrefix(ref, "local:") {
+			ref = KEKRefLocal
+		}
 		switch ref {
 		case "", KEKRefLocal:
 			path := filepath.Join(keyringDir, KEKFileName)

--- a/internal/backup/keystore/local_ref_test.go
+++ b/internal/backup/keystore/local_ref_test.go
@@ -1,0 +1,60 @@
+package keystore
+
+import (
+	"context"
+	"testing"
+
+	"github.com/cybertec-postgresql/pg_hardstorage/internal/backup"
+	"github.com/cybertec-postgresql/pg_hardstorage/internal/plugin/encryption"
+)
+
+// Local rotation stamps refs like "local:v2" on rotated manifests
+// (kms rotate refuses old==new refs, so a new local ref is forced).
+// Both resolvers used by restore/verify/drill must route ANY local:*
+// ref to the keyring — restricting them to exactly "local:default"
+// made every rotated backup unrestorable by any shipped code path.
+func TestLocalRefs_ResolveToKeyring(t *testing.T) {
+	dir := t.TempDir()
+	kek, _, err := LoadOrGenerateKEK(dir)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	for _, ref := range []string{"", KEKRefLocal, "local:v2", "local:2026-rotation"} {
+		got, err := KEKResolver(dir)(ref)
+		if err != nil {
+			t.Errorf("KEKResolver(%q): %v — rotated backups with this ref are unrestorable", ref, err)
+			continue
+		}
+		if got != kek {
+			t.Errorf("KEKResolver(%q) returned different key material", ref)
+		}
+	}
+
+	// UnwrapDEK: wrap a DEK under the keyring KEK (same envelope
+	// encryption.Wrap produces on manifests), then unwrap via a
+	// rotated-style ref.
+	var dek [encryption.KeyLen]byte
+	for i := range dek {
+		dek[i] = byte(i)
+	}
+	wrapped, err := encryption.Wrap(kek, dek)
+	if err != nil {
+		t.Fatal(err)
+	}
+	got, err := UnwrapDEK(context.Background(), "local:v2", wrapped, UnwrapOpts{KeyringDir: dir})
+	if err != nil {
+		t.Fatalf("UnwrapDEK(local:v2): %v — rotated manifests cannot be decrypted", err)
+	}
+	if string(got) != string(dek[:]) {
+		t.Fatal("UnwrapDEK(local:v2) returned wrong DEK")
+	}
+}
+
+// rotate.go (package backup) cannot import keystore (import cycle),
+// so it mirrors KEKRefLocal as a private constant. Pin them together.
+func TestLocalDefaultRefConstantsAgree(t *testing.T) {
+	if got := backup.LocalDefaultKEKRefForTest(); got != KEKRefLocal {
+		t.Fatalf("backup.localDefaultKEKRef = %q, keystore.KEKRefLocal = %q — the rotation alias slot would target the wrong ref", got, KEKRefLocal)
+	}
+}

--- a/internal/backup/keystore/unwrap.go
+++ b/internal/backup/keystore/unwrap.go
@@ -7,6 +7,7 @@ import (
 	"crypto/cipher"
 	"errors"
 	"fmt"
+	"strings"
 	"time"
 
 	"github.com/cybertec-postgresql/pg_hardstorage/internal/kms"
@@ -97,7 +98,12 @@ func UnwrapDEK(ctx context.Context, kekRef string, wrappedDEK []byte, opts Unwra
 		metrics.ObserveKMSUnwrap(scheme, result, time.Since(start).Seconds())
 	}()
 
-	if kekRef == "" || kekRef == KEKRefLocal {
+	// Any local:* ref routes to the keyring (see KEKResolver: local
+	// rotation stamps refs like "local:v2" on rotated manifests, and
+	// the KMS registry has no "local" provider — routing those refs
+	// there returned ErrUnknownScheme and made rotated backups
+	// unrestorable).
+	if kekRef == "" || strings.HasPrefix(kekRef, "local:") {
 		if opts.KeyringDir == "" {
 			return nil, errors.New("keystore: UnwrapDEK with local KEKRef requires opts.KeyringDir")
 		}

--- a/internal/backup/manifest.go
+++ b/internal/backup/manifest.go
@@ -541,6 +541,32 @@ func (m *Manifest) Validate() error {
 	if m.StartLSN == "" || m.StopLSN == "" {
 		return fmt.Errorf("manifest: missing LSN(s) start=%q stop=%q", m.StartLSN, m.StopLSN)
 	}
+	// Chain invariants. An incremental without a parent passes every
+	// other gate, skips Commit's parent-liveness check (which keys on
+	// ParentBackupID != ""), is invisible to soft-delete chain
+	// protection — and is structurally unrestorable from the moment
+	// it commits (pg_combinebackup needs the parent). Refuse at the
+	// same gate that already refuses undecryptable encryption shapes.
+	switch m.Type {
+	case BackupTypeFull, BackupTypeSnapshot:
+		if m.ParentBackupID != "" {
+			return fmt.Errorf("manifest: type %q must not carry parent_backup_id (got %q)", m.Type, m.ParentBackupID)
+		}
+	case BackupTypeIncremental:
+		if m.ParentBackupID == "" {
+			return errors.New("manifest: type incremental_lsn requires parent_backup_id — an incremental without its parent is unrestorable (pg_combinebackup needs the chain)")
+		}
+		if m.ParentBackupID == m.BackupID {
+			return fmt.Errorf("manifest: parent_backup_id equals backup_id (%q) — self-referential chain", m.BackupID)
+		}
+	case "":
+		return errors.New("manifest: type is empty")
+	default:
+		return fmt.Errorf("manifest: unknown type %q", m.Type)
+	}
+	if m.Timeline < 1 {
+		return fmt.Errorf("manifest: timeline=%d (must be ≥1)", m.Timeline)
+	}
 	if m.BackupLabel == "" {
 		return errors.New("manifest: backup_label is empty (required for restore)")
 	}

--- a/internal/backup/manifest_chain_validate_test.go
+++ b/internal/backup/manifest_chain_validate_test.go
@@ -1,0 +1,84 @@
+package backup_test
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/cybertec-postgresql/pg_hardstorage/internal/backup"
+)
+
+// A Type=incremental_lsn manifest with an empty ParentBackupID used
+// to pass Validate and commit cleanly — then skipped Commit's
+// parent-liveness check (keyed on ParentBackupID != ""), was
+// invisible to soft-delete chain protection, and failed only at
+// restore with chain.no_full_anchor: a "successful", signed backup
+// that was structurally unrestorable from the moment of commit.
+func TestManifestValidate_ChainInvariants(t *testing.T) {
+	base := func() *backup.Manifest {
+		return &backup.Manifest{
+			Schema:           backup.Schema,
+			BackupID:         "db1.full.20260430T120000Z.aaaa",
+			Deployment:       "db1",
+			Type:             backup.BackupTypeFull,
+			PGVersion:        17,
+			SystemIdentifier: "7000000000000000001",
+			StartLSN:         "0/3000028",
+			StopLSN:          "0/30001A0",
+			Timeline:         1,
+			BackupLabel:      "START WAL LOCATION: 0/3000028\n",
+			Tablespaces:      []backup.Tablespace{{OID: 1663, Location: "pg_default"}},
+			Files:            []backup.FileEntry{},
+		}
+	}
+
+	cases := []struct {
+		name    string
+		mutate  func(*backup.Manifest)
+		wantErr string
+	}{
+		{"incremental_without_parent", func(m *backup.Manifest) {
+			m.Type = backup.BackupTypeIncremental
+			m.ParentBackupID = ""
+		}, "requires parent_backup_id"},
+		{"incremental_self_parent", func(m *backup.Manifest) {
+			m.Type = backup.BackupTypeIncremental
+			m.ParentBackupID = m.BackupID
+		}, "self-referential"},
+		{"full_with_parent", func(m *backup.Manifest) {
+			m.ParentBackupID = "db1.full.20260429T120000Z.zzzz"
+		}, "must not carry parent_backup_id"},
+		{"unknown_type", func(m *backup.Manifest) {
+			m.Type = "differential"
+		}, "unknown type"},
+		{"empty_type", func(m *backup.Manifest) {
+			m.Type = ""
+		}, "type is empty"},
+		{"zero_timeline", func(m *backup.Manifest) {
+			m.Timeline = 0
+		}, "timeline"},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			m := base()
+			tc.mutate(m)
+			err := m.Validate()
+			if err == nil {
+				t.Fatalf("Validate accepted a %s manifest — it would commit green and fail only at restore", tc.name)
+			}
+			if !strings.Contains(err.Error(), tc.wantErr) {
+				t.Errorf("err = %v, want substring %q", err, tc.wantErr)
+			}
+		})
+	}
+
+	// The valid shapes must keep passing.
+	if err := base().Validate(); err != nil {
+		t.Errorf("valid full manifest refused: %v", err)
+	}
+	inc := base()
+	inc.Type = backup.BackupTypeIncremental
+	inc.ParentBackupID = "db1.full.20260429T120000Z.zzzz"
+	if err := inc.Validate(); err != nil {
+		t.Errorf("valid incremental refused: %v", err)
+	}
+}

--- a/internal/backup/manifest_store.go
+++ b/internal/backup/manifest_store.go
@@ -1545,7 +1545,50 @@ func (ms *ManifestStore) Undelete(ctx context.Context, deployment, backupID stri
 			Missing:     missing,
 		}
 	}
+	// Parent-chain pre-flight: resurrecting an incremental whose
+	// ancestors stay tombstoned hands back a healthy-LOOKING backup
+	// that every restore refuses (chain.broken_tombstoned) — and once
+	// the parent's tombstone ages past GC grace, its chunks and WAL
+	// are reaped and the resurrected leaf becomes PERMANENTLY
+	// unrestorable while still listing as live. Walk the chain and
+	// fail closed, naming the first dead ancestor; UndeleteForce
+	// remains the eyes-open override.
+	cur := m
+	for cur.ParentBackupID != "" {
+		parentDead, perr := ms.IsTombstoned(ctx, deployment, cur.ParentBackupID)
+		if perr != nil {
+			return false, fmt.Errorf("backup: Undelete: tombstone check on ancestor %s: %w", cur.ParentBackupID, perr)
+		}
+		if parentDead {
+			return false, &UndeleteParentTombstonedError{
+				Deployment: deployment,
+				BackupID:   backupID,
+				Ancestor:   cur.ParentBackupID,
+			}
+		}
+		parent, perr2 := ms.readManifestUnverified(ctx, deployment, cur.ParentBackupID)
+		if perr2 != nil {
+			return false, fmt.Errorf("backup: Undelete: read ancestor %s: %w", cur.ParentBackupID, perr2)
+		}
+		cur = parent
+	}
 	return ms.removeTombstone(ctx, deployment, backupID)
+}
+
+// UndeleteParentTombstonedError is returned by Undelete when the
+// manifest being resurrected is an incremental whose ancestor is
+// still tombstoned — restoring the chain requires undeleting the
+// ancestor(s) first (oldest-first), or UndeleteForce for the
+// metadata-only forensic case.
+type UndeleteParentTombstonedError struct {
+	Deployment string
+	BackupID   string
+	Ancestor   string
+}
+
+func (e *UndeleteParentTombstonedError) Error() string {
+	return fmt.Sprintf("backup: refusing to undelete %s/%s: its ancestor %s is still tombstoned — the resurrected incremental would be unrestorable (and permanently so once GC grace expires). Undelete the ancestor first, or use the force mode for metadata-only resurrection",
+		e.Deployment, e.BackupID, e.Ancestor)
 }
 
 // UndeleteForce removes a backup's tombstone WITHOUT the chunk

--- a/internal/backup/rotate.go
+++ b/internal/backup/rotate.go
@@ -11,8 +11,11 @@ import (
 	"sort"
 	"time"
 
+	"strings"
+
 	"github.com/cybertec-postgresql/pg_hardstorage/internal/plugin/encryption"
 	"github.com/cybertec-postgresql/pg_hardstorage/internal/plugin/storage"
+	"github.com/cybertec-postgresql/pg_hardstorage/internal/repo/sharedkey"
 )
 
 // RotateKEKSchema is the on-disk version tag for RotateKEKResult bodies.
@@ -134,6 +137,13 @@ type RotateKEKResult struct {
 	SkippedDifferentKEK int `json:"skipped_different_kek"`
 	Failed              int `json:"failed"`
 
+	// SharedDEKMigrated reports whether the authoritative
+	// keys/shared-dek/ object was rewrapped to the new (ref, KEK) as
+	// part of this pass. False on dry-runs, on legacy repos that
+	// never had the object, and when Failed > 0 (migration only runs
+	// after a clean manifest pass).
+	SharedDEKMigrated bool `json:"shared_dek_migrated,omitempty"`
+
 	// ReplicaFailures counts manifests where the primary rewrite
 	// succeeded but the replica copy update failed. The primary is
 	// authoritative; the replica is best-effort redundancy. Each
@@ -245,9 +255,61 @@ func RotateKEK(ctx context.Context, sp storage.StoragePlugin, opts RotateKEKOpti
 		}
 	}
 
+	// Migrate the authoritative shared-DEK object (keys/shared-dek/)
+	// across the rotation. Manifests alone are not enough: the next
+	// backup's ResolveOrMint consults this object FIRST, and a wrap
+	// left under the retired KEK bricks every future backup and
+	// `wal stream` for this ref (they refuse — correctly — to mint a
+	// divergent DEK). Same-DEK invariant: only the wrapping changes.
+	if !opts.DryRun && res.Failed == 0 {
+		unwrapOld := func(w []byte) ([]byte, error) {
+			d, err := encryption.Unwrap(opts.OldKEK, w)
+			if err != nil {
+				return nil, err
+			}
+			return d[:], nil
+		}
+		wrapNew := func(d [encryption.KeyLen]byte) ([]byte, error) {
+			return encryption.Wrap(opts.NewKEK, d)
+		}
+		migrated, rerr := sharedkey.Rewrap(ctx, sp, opts.OldKEKRef, opts.NewKEKRef, unwrapOld, wrapNew, true)
+		if rerr != nil {
+			finish()
+			return res, fmt.Errorf("backup rotate-kek: migrate shared-DEK object: %w", rerr)
+		}
+		res.SharedDEKMigrated = migrated
+
+		// Local-custody alias: the CLI and agent stamp the FIXED ref
+		// "local:default" (keystore.KEKRefLocal) on every local-KEK
+		// backup, regardless of what ref the rotation introduced. If
+		// that slot stops resolving, the next local backup mints a
+		// FRESH DEK — and content-addressed dedup then welds new
+		// manifests onto chunks sealed with the old DEK (unrestorable,
+		// issue #28 class). Keep the alias slot on the SAME DEK,
+		// wrapped under the new KEK.
+		if migrated && strings.HasPrefix(opts.NewKEKRef, "local:") && opts.NewKEKRef != localDefaultKEKRef {
+			unwrapNew := func(w []byte) ([]byte, error) {
+				d, err := encryption.Unwrap(opts.NewKEK, w)
+				if err != nil {
+					return nil, err
+				}
+				return d[:], nil
+			}
+			if _, aerr := sharedkey.Rewrap(ctx, sp, opts.NewKEKRef, localDefaultKEKRef, unwrapNew, wrapNew, false); aerr != nil {
+				finish()
+				return res, fmt.Errorf("backup rotate-kek: refresh local-default shared-DEK alias: %w", aerr)
+			}
+		}
+	}
+
 	finish()
 	return res, nil
 }
+
+// localDefaultKEKRef mirrors keystore.KEKRefLocal ("local:default").
+// Duplicated because keystore imports this package; a cross-check
+// test in keystore pins the two constants together.
+const localDefaultKEKRef = "local:default"
 
 type rotateOutcome int
 
@@ -390,22 +452,26 @@ func healStaleReplica(ctx context.Context, sp storage.StoragePlugin, m *Manifest
 // maintenance window; the rotation primitive's contract surfaces
 // this in the package docs.
 func overwriteManifest(ctx context.Context, sp storage.StoragePlugin, key string, body []byte, retainUntil time.Time, mode storage.WORMMode) error {
-	tmp := key + ".rotate." + randSuffix()
-	if _, err := sp.Put(ctx, tmp, bytes.NewReader(body), storage.PutOptions{
+	// Direct overwriting Put. Every backend's Put replaces the key
+	// atomically (fs/sftp: tmp + POSIX rename; object stores: PUT is
+	// last-writer-wins on the whole object), so there is never a
+	// moment without a valid manifest body at key.
+	//
+	// The previous shape — Put tmp, DELETE the original, then
+	// RenameIfNotExists(tmp→key) — had a fatal failure mode: after
+	// the delete, a transient rename failure took the "cleanup" path
+	// and deleted the tmp too, destroying the only manifest copy at
+	// the primary key. The backup then vanished from List/retention
+	// AND from GC's reference walk (which reads only .../manifest.json),
+	// so the next `repo gc --apply` reaped all of its chunks —
+	// permanent, silent backup loss triggered by one flaky rename
+	// during routine key rotation. A crash between the delete and the
+	// rename stranded the manifest under a name nothing reads, with
+	// the same GC outcome.
+	if _, err := sp.Put(ctx, key, bytes.NewReader(body), storage.PutOptions{
 		ContentLength: int64(len(body)),
 	}); err != nil {
-		return fmt.Errorf("write tmp: %w", err)
-	}
-	if err := sp.Delete(ctx, key); err != nil {
-		// Best-effort cleanup of tmp; the original-delete error is
-		// what matters.
-		_ = sp.Delete(ctx, tmp)
-		return fmt.Errorf("delete original: %w", err)
-	}
-	if err := sp.RenameIfNotExists(ctx, tmp, key); err != nil {
-		// Cleanup attempt, then surface.
-		_ = sp.Delete(ctx, tmp)
-		return fmt.Errorf("rename tmp -> original: %w", err)
+		return fmt.Errorf("overwrite manifest: %w", err)
 	}
 	// Re-apply the repo's WORM lock to the rewritten manifest so a rotation
 	// on a compliance repo doesn't leave it deletable. Empty mode →
@@ -445,3 +511,8 @@ func recordRotateFailure(res *RotateKEKResult, deployment, backupID string, err 
 		Err:        err.Error(),
 	})
 }
+
+// LocalDefaultKEKRefForTest exposes localDefaultKEKRef so the
+// keystore package (which this package cannot import) can pin it
+// against keystore.KEKRefLocal in a test.
+func LocalDefaultKEKRefForTest() string { return localDefaultKEKRef }

--- a/internal/backup/rotate_atomicity_test.go
+++ b/internal/backup/rotate_atomicity_test.go
@@ -1,0 +1,82 @@
+package backup_test
+
+import (
+	"context"
+	"errors"
+	"io"
+	"strings"
+	"testing"
+
+	"github.com/cybertec-postgresql/pg_hardstorage/internal/backup"
+	"github.com/cybertec-postgresql/pg_hardstorage/internal/plugin/storage"
+)
+
+// failingPutSP wraps a StoragePlugin and fails Put for keys matching
+// a substring, simulating a transient storage error mid-rotation.
+type failingPutSP struct {
+	storage.StoragePlugin
+	failSubstr string
+	failed     bool
+}
+
+func (f *failingPutSP) Put(ctx context.Context, key string, r io.Reader, opts storage.PutOptions) (storage.PutResult, error) {
+	if !f.failed && strings.Contains(key, f.failSubstr) && strings.HasSuffix(key, "/manifest.json") {
+		f.failed = true
+		return storage.PutResult{}, errors.New("injected transient storage failure")
+	}
+	return f.StoragePlugin.Put(ctx, key, r, opts)
+}
+
+// KEK rotation used to rewrite manifests as Put-tmp → DELETE original
+// → RenameIfNotExists, and on a rename failure it "cleaned up" by
+// deleting the tmp — destroying the only manifest copy at the primary
+// key. The backup then vanished from List/retention and from GC's
+// reference walk, so the next `repo gc --apply` reaped its chunks:
+// permanent loss triggered by one flaky rename during routine key
+// rotation. The rewrite must be a single atomic overwrite — after ANY
+// failure a valid manifest body (old or new) must still exist at the
+// primary key.
+func TestRotateKEK_FailedRewriteNeverLosesTheManifest(t *testing.T) {
+	w := setupRotateWorld(t)
+	ctx := context.Background()
+	oldKEK, newKEK := mkKEK(t), mkKEK(t)
+
+	const backupID = "db1.full.20260430T120000Z.cccc"
+	w.commitEncrypted(t, "db1", backupID, oldKEK, "local:default", 0)
+
+	fsp := &failingPutSP{StoragePlugin: w.sp, failSubstr: backupID}
+	res, err := backup.RotateKEK(ctx, fsp, backup.RotateKEKOptions{
+		OldKEKRef: "local:default", OldKEK: oldKEK,
+		NewKEKRef: "local:v2", NewKEK: newKEK,
+		Signer: w.signer, Verifier: w.verifier,
+	})
+	if err != nil {
+		t.Fatalf("RotateKEK returned hard error: %v", err)
+	}
+	if res.Failed != 1 {
+		t.Fatalf("Failed = %d, want 1 (the injected Put failure)", res.Failed)
+	}
+
+	// THE invariant: the manifest must still be present and readable
+	// at its primary key — under either KEK ref, but never absent.
+	m, rerr := w.store.Read(ctx, "db1", backupID, w.verifier)
+	if rerr != nil {
+		t.Fatalf("manifest LOST after failed rotation rewrite: %v — GC would reap this backup's chunks", rerr)
+	}
+	if m.Encryption == nil {
+		t.Fatal("manifest survived but lost its encryption block")
+	}
+
+	// And a retry with a healthy plugin completes the rotation.
+	res2, err := backup.RotateKEK(ctx, w.sp, backup.RotateKEKOptions{
+		OldKEKRef: "local:default", OldKEK: oldKEK,
+		NewKEKRef: "local:v2", NewKEK: newKEK,
+		Signer: w.signer, Verifier: w.verifier,
+	})
+	if err != nil {
+		t.Fatalf("retry: %v", err)
+	}
+	if res2.Rotated+res2.AlreadyRotated != 1 || res2.Failed != 0 {
+		t.Fatalf("retry: rotated=%d already=%d failed=%d", res2.Rotated, res2.AlreadyRotated, res2.Failed)
+	}
+}

--- a/internal/backup/rotate_shareddek_test.go
+++ b/internal/backup/rotate_shareddek_test.go
@@ -1,0 +1,140 @@
+package backup_test
+
+import (
+	"context"
+	"testing"
+
+	"github.com/cybertec-postgresql/pg_hardstorage/internal/backup"
+	"github.com/cybertec-postgresql/pg_hardstorage/internal/plugin/encryption"
+	"github.com/cybertec-postgresql/pg_hardstorage/internal/repo/sharedkey"
+)
+
+// `kms rotate` used to rewrap every manifest but leave the
+// authoritative shared-DEK object (keys/shared-dek/) under the
+// retired KEK. The next backup's ResolveOrMint found an object it
+// could not unwrap and every future backup and `wal stream`
+// hard-failed (UnusableCandidate) until the operator deleted an
+// undocumented internal object. Rotation must migrate the object —
+// same DEK, new wrap — and, for local custody, keep the fixed
+// "local:default" ref (which the CLI/agent stamp on every backup)
+// resolving to that same DEK so dedup never welds new manifests onto
+// chunks sealed with a different key.
+func TestRotateKEK_MigratesSharedDEKObject(t *testing.T) {
+	w := setupRotateWorld(t)
+	ctx := context.Background()
+	oldKEK, newKEK := mkKEK(t), mkKEK(t)
+
+	unwrapWith := func(kek [encryption.KeyLen]byte) sharedkey.Unwrapper {
+		return func(wrapped []byte) ([]byte, error) {
+			d, err := encryption.Unwrap(kek, wrapped)
+			if err != nil {
+				return nil, err
+			}
+			return d[:], nil
+		}
+	}
+	wrapWith := func(kek [encryption.KeyLen]byte) sharedkey.Wrapper {
+		return func(dek [encryption.KeyLen]byte) ([]byte, error) {
+			return encryption.Wrap(kek, dek)
+		}
+	}
+
+	// Seed: one encrypted manifest + the shared-DEK object, both
+	// under local:default / oldKEK — the post-#31 steady state.
+	w.commitEncrypted(t, "db1", "db1.full.20260430T120000Z.aaaa", oldKEK, "local:default", 0)
+	seed, err := sharedkey.ResolveOrMint(ctx, w.sp, "local:default", unwrapWith(oldKEK), wrapWith(oldKEK))
+	if err != nil || !seed.Have {
+		t.Fatalf("seed shared DEK: have=%v err=%v", seed.Have, err)
+	}
+
+	res, err := backup.RotateKEK(ctx, w.sp, backup.RotateKEKOptions{
+		OldKEKRef: "local:default", OldKEK: oldKEK,
+		NewKEKRef: "local:v2", NewKEK: newKEK,
+		Signer: w.signer, Verifier: w.verifier,
+	})
+	if err != nil {
+		t.Fatalf("RotateKEK: %v", err)
+	}
+	if res.Rotated != 1 || res.Failed != 0 {
+		t.Fatalf("rotated=%d failed=%d, want 1/0", res.Rotated, res.Failed)
+	}
+	if !res.SharedDEKMigrated {
+		t.Fatal("SharedDEKMigrated=false — the shared-DEK object was left under the retired KEK")
+	}
+
+	// The NEXT backup resolves under the new ref with the new KEK and
+	// must get the SAME DEK (chunk dedup depends on it).
+	got, err := sharedkey.ResolveOrMint(ctx, w.sp, "local:v2", unwrapWith(newKEK), wrapWith(newKEK))
+	if err != nil {
+		t.Fatal(err)
+	}
+	if got.UnusableCandidate {
+		t.Fatal("local:v2 resolve → UnusableCandidate: backups are bricked after rotation")
+	}
+	if !got.Have || got.DEK != seed.DEK {
+		t.Fatalf("local:v2 DEK changed across rotation (have=%v) — dedup would weld manifests onto chunks sealed with the old DEK", got.Have)
+	}
+
+	// The CLI/agent stamp the FIXED ref local:default on every local
+	// backup; that slot must also resolve to the SAME DEK under the
+	// new KEK (the alias slot rotation writes).
+	got2, err := sharedkey.ResolveOrMint(ctx, w.sp, "local:default", unwrapWith(newKEK), wrapWith(newKEK))
+	if err != nil {
+		t.Fatal(err)
+	}
+	if got2.UnusableCandidate || !got2.Have || got2.DEK != seed.DEK {
+		t.Fatalf("local:default after rotation: have=%v unusable=%v sameDEK=%v — the next scheduled backup would brick or fork the DEK",
+			got2.Have, got2.UnusableCandidate, got2.DEK == seed.DEK)
+	}
+}
+
+// A stale shared-DEK object that will not unwrap (a rotation that
+// predates the migration fix) must no longer hard-fail every backup:
+// ResolveOrMint falls through to the manifest scan and adopts the
+// DEK from a freshly-rotated manifest.
+func TestResolveOrMint_StaleObjectFallsThroughToManifests(t *testing.T) {
+	w := setupRotateWorld(t)
+	ctx := context.Background()
+	oldKEK, newKEK := mkKEK(t), mkKEK(t)
+
+	unwrapNew := func(wrapped []byte) ([]byte, error) {
+		d, err := encryption.Unwrap(newKEK, wrapped)
+		if err != nil {
+			return nil, err
+		}
+		return d[:], nil
+	}
+	wrapNew := func(dek [encryption.KeyLen]byte) ([]byte, error) {
+		return encryption.Wrap(newKEK, dek)
+	}
+	unwrapOld := func(wrapped []byte) ([]byte, error) {
+		d, err := encryption.Unwrap(oldKEK, wrapped)
+		if err != nil {
+			return nil, err
+		}
+		return d[:], nil
+	}
+	wrapOld := func(dek [encryption.KeyLen]byte) ([]byte, error) {
+		return encryption.Wrap(oldKEK, dek)
+	}
+
+	// Plant a STALE shared-DEK object wrapped under the OLD KEK (what
+	// a pre-fix rotation leaves behind): mint it into an empty repo…
+	if seed, err := sharedkey.ResolveOrMint(ctx, w.sp, "local:default", unwrapOld, wrapOld); err != nil || !seed.Have {
+		t.Fatalf("seed stale object: have=%v err=%v", seed.Have, err)
+	}
+	// …then commit a manifest wrapped under the NEW KEK at the same
+	// ref (as a completed legacy manifest rotation leaves them).
+	w.commitEncrypted(t, "db1", "db1.full.20260430T120000Z.bbbb", newKEK, "local:default", 0)
+
+	got, err := sharedkey.ResolveOrMint(ctx, w.sp, "local:default", unwrapNew, wrapNew)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if got.UnusableCandidate {
+		t.Fatal("stale object still hard-fails ResolveOrMint — pre-fix behaviour (every backup bricked)")
+	}
+	if !got.Have {
+		t.Fatal("expected DEK adopted from the rotated manifest")
+	}
+}

--- a/internal/backup/runner/runner.go
+++ b/internal/backup/runner/runner.go
@@ -516,6 +516,23 @@ func Take(ctx context.Context, opts TakeOptions) (*Result, error) {
 	// Chunks are written DurabilityDeferred — no per-chunk fsync —
 	// and made crash-durable by a single cas.Barrier after
 	// BASE_BACKUP completes, before the manifest is committed.
+	//
+	// That invariant only holds when the backend can actually enforce
+	// durability somewhere: either Barrier is real (DurabilityBarrier)
+	// or every Put is durable on return (InlineDurable). A backend
+	// with NEITHER (sftp/scp: tmp+rename into the remote page cache,
+	// NopBarrier) silently voids the "chunks durable before manifest
+	// commit" guarantee — after a remote power loss the manifest can
+	// survive while chunk keys hold torn bytes, and existence-based
+	// dedup then propagates the torn chunk into every future backup.
+	// We cannot conjure remote fsync, but we can refuse to be silent.
+	if caps := sp.Capabilities(); !caps.InlineDurable && !caps.DurabilityBarrier {
+		emit(output.NewEvent(output.SeverityWarning, "backup", "durability_unenforceable").
+			WithSubject(output.Subject{Deployment: opts.Deployment}).
+			WithBody(map[string]any{
+				"message": "this storage backend can neither fsync on demand (no durability barrier) nor guarantee durable writes (no inline durability): a power loss on the storage host can leave a committed manifest whose chunks are torn or missing. Prefer a backend with real durability (file/s3) for primary backups, or accept the risk knowingly.",
+			}))
+	}
 	casOpts := []casdefault.Option{
 		casdefault.WithCompressionLevel(repoMeta.Compression),
 		casdefault.WithChunkDurability(storage.DurabilityDeferred),

--- a/internal/backup/undelete_chain_test.go
+++ b/internal/backup/undelete_chain_test.go
@@ -1,0 +1,54 @@
+package backup_test
+
+import (
+	"context"
+	"errors"
+	"testing"
+
+	"github.com/cybertec-postgresql/pg_hardstorage/internal/backup"
+)
+
+// Undelete used to check only chunk existence: resurrecting an
+// incremental whose parent chain stayed tombstoned handed back a
+// live-listing backup that every restore refuses
+// (chain.broken_tombstoned) — and once the parent's tombstone aged
+// past GC grace, its chunks and WAL were reaped, making the
+// resurrected leaf PERMANENTLY unrestorable while presenting as
+// healthy. Undelete must fail closed naming the dead ancestor.
+func TestUndelete_RefusesWhenAncestorTombstoned(t *testing.T) {
+	store, sp, signer, _ := newStore(t)
+	commitChain(t, store, signer, "db1", []chainLink{
+		{id: "F", btype: backup.BackupTypeFull},
+		{id: "I1", parent: "F", btype: backup.BackupTypeIncremental},
+	})
+	seedSampleChunks(t, sp)
+
+	if _, err := store.SoftDeleteCascade(context.Background(), "db1", "F", "manual", "test"); err != nil {
+		t.Fatalf("cascade delete: %v", err)
+	}
+
+	// The natural "get my newest backup back" move: undelete the leaf.
+	_, err := store.Undelete(context.Background(), "db1", "I1")
+	if err == nil {
+		t.Fatal("Undelete resurrected an incremental whose full parent is still tombstoned — unrestorable-but-live backup")
+	}
+	var pe *backup.UndeleteParentTombstonedError
+	if !errors.As(err, &pe) {
+		t.Fatalf("err = %v, want UndeleteParentTombstonedError", err)
+	}
+	if pe.Ancestor != "F" {
+		t.Errorf("Ancestor = %q, want F", pe.Ancestor)
+	}
+	// The leaf's tombstone must remain (fail closed, no half-state).
+	if dead, _ := store.IsTombstoned(context.Background(), "db1", "I1"); !dead {
+		t.Error("I1 tombstone removed despite the refusal")
+	}
+
+	// Correct order works: parent first, then the leaf.
+	if _, err := store.Undelete(context.Background(), "db1", "F"); err != nil {
+		t.Fatalf("undelete parent: %v", err)
+	}
+	if _, err := store.Undelete(context.Background(), "db1", "I1"); err != nil {
+		t.Fatalf("undelete leaf after parent: %v", err)
+	}
+}

--- a/internal/cli/verify_full.go
+++ b/internal/cli/verify_full.go
@@ -150,6 +150,10 @@ func runVerifyFull(cmd *cobra.Command, deployment, backupID, repoURL, pgMajorOve
 	res, err := sandbox.Verify(cmd.Context(), sandbox.Options{
 		DataDir: tmp,
 		PGMajor: major,
+		// The restore above writes backup_manifest whenever the
+		// manifest carries it — so a "could not open backup_manifest"
+		// from pg_verifybackup is an environment fault, not a skip.
+		ManifestCaptured: len(m.PGBackupManifest) > 0,
 	})
 	if err != nil {
 		return output.NewError("verify.sandbox_failed",

--- a/internal/cli/wal.go
+++ b/internal/cli/wal.go
@@ -1863,6 +1863,21 @@ func streamAttempt(
 	timeline = uint32(identity.Timeline)
 	identityID = identity.SystemID
 
+	if attempt == 1 {
+		// Same durability honesty as the backup runner: on a backend
+		// with neither a real Barrier nor inline-durable Puts
+		// (sftp/scp), segment "commits" reach only the remote page
+		// cache — yet the slot's restart_lsn advances past them, so a
+		// storage-host power loss loses WAL that PG has already been
+		// told is safe and has recycled. Warn loudly.
+		if caps := sp.Capabilities(); !caps.InlineDurable && !caps.DurabilityBarrier {
+			_ = d.Event(repoCtx, output.NewEvent(output.SeverityWarning, "wal.durability", "unenforceable").
+				WithBody(map[string]any{
+					"message": "this storage backend can neither fsync on demand nor guarantee durable writes: a storage-host power loss can lose WAL segments the replication slot has already advanced past (PG will have recycled them — unhealable gap). Prefer a backend with real durability (file/s3) for WAL archiving.",
+				}))
+		}
+	}
+
 	var slotInfo *replication.SlotInfo
 	if opts.noSlot {
 		if attempt == 1 {

--- a/internal/plugin/storage/s3/capability_honesty_test.go
+++ b/internal/plugin/storage/s3/capability_honesty_test.go
@@ -1,0 +1,57 @@
+package s3
+
+import (
+	"context"
+	"net/url"
+	"strings"
+	"testing"
+
+	"github.com/cybertec-postgresql/pg_hardstorage/internal/plugin/storage"
+)
+
+// The plugin used to claim ConditionalPut=true for EVERY endpoint.
+// On AWS proper the claim is native; on ?endpoint= overrides it was a
+// guess — and the contract harness has already caught MinIO silently
+// ignoring the same If-None-Match directive on CopyObject. The claim
+// is load-bearing: audit's lost-slot read-back and the runner's
+// lease_unenforceable warning are DISABLED when it is true, so a lie
+// silently removes the exact mitigations built for dishonest
+// backends (single-winner DEK mint, lease, audit chain, repo-init
+// identity claim). Custom endpoints must therefore report false
+// unless the operator vouches with ?conditional_put=native.
+func TestCapabilities_ConditionalPutHonesty(t *testing.T) {
+	t.Setenv("AWS_ACCESS_KEY_ID", "test")
+	t.Setenv("AWS_SECRET_ACCESS_KEY", "test")
+	t.Setenv("AWS_REGION", "us-east-1")
+
+	open := func(t *testing.T, raw string) *Plugin {
+		t.Helper()
+		u, err := url.Parse(raw)
+		if err != nil {
+			t.Fatal(err)
+		}
+		p := &Plugin{}
+		if err := p.Open(context.Background(), storage.StorageConfig{URL: u}); err != nil {
+			t.Fatalf("Open(%s): %v", raw, err)
+		}
+		t.Cleanup(func() { _ = p.Close() })
+		return p
+	}
+
+	if p := open(t, "s3://bucket/prefix?region=us-east-1"); !p.Capabilities().ConditionalPut {
+		t.Error("AWS-native endpoint must keep ConditionalPut=true")
+	}
+	if p := open(t, "s3://bucket/prefix?endpoint=http://127.0.0.1:9000&path_style=true"); p.Capabilities().ConditionalPut {
+		t.Error("custom endpoint without a vouch claims ConditionalPut=true — the capability lie disables the audit read-back and lease warning mitigations")
+	}
+	if p := open(t, "s3://bucket/prefix?endpoint=http://127.0.0.1:9000&path_style=true&conditional_put=native"); !p.Capabilities().ConditionalPut {
+		t.Error("operator vouched with conditional_put=native but the capability stayed false")
+	}
+
+	u, _ := url.Parse("s3://bucket/prefix?endpoint=http://127.0.0.1:9000&conditional_put=maybe")
+	p := &Plugin{}
+	err := p.Open(context.Background(), storage.StorageConfig{URL: u})
+	if err == nil || !strings.Contains(err.Error(), "conditional_put") {
+		t.Errorf("unknown conditional_put value accepted (err=%v) — typos would silently drop the vouch", err)
+	}
+}

--- a/internal/plugin/storage/s3/s3.go
+++ b/internal/plugin/storage/s3/s3.go
@@ -17,6 +17,11 @@
 //	              not host). Required for MinIO/localstack with non-DNS
 //	              bucket names.
 //	storage_class default StorageClass for Put when none is set per-request.
+//	conditional_put "native" vouches that a custom ?endpoint= enforces
+//	              `If-None-Match: *` atomically (MinIO ≥ RELEASE.2024,
+//	              Cloudflare R2). Without the vouch, custom endpoints
+//	              report ConditionalPut=false so single-winner callers
+//	              degrade loudly instead of trusting an unverified claim.
 //
 // Authentication is delegated to the AWS SDK v2 default credential
 // chain (env vars, IRSA, IAM role, profile, SSO). v0.1 does not
@@ -74,6 +79,12 @@ type Plugin struct {
 	prefix       string // includes a trailing "/" or is empty
 	storageClass string
 	region       string // resolved AWS region; reported via Region()
+
+	// conditionalPut records whether this endpoint is trusted to
+	// honour `If-None-Match: *` atomically. True for AWS proper;
+	// false for ?endpoint= overrides unless the operator passes
+	// ?conditional_put=native. See Capabilities.
+	conditionalPut bool
 }
 
 // Name implements storage.StoragePlugin.
@@ -106,6 +117,27 @@ func (p *Plugin) Open(ctx context.Context, cfg storage.StorageConfig) error {
 	endpoint := q.Get("endpoint")
 	pathStyle := q.Get("path_style") == "true"
 	storageClass := q.Get("storage_class")
+
+	// Conditional-put honesty. AWS S3 enforces `If-None-Match: *`
+	// natively and atomically. S3-COMPATIBLE endpoints are a mixed
+	// bag — the contract harness has already caught MinIO silently
+	// IGNORING the same directive on CopyObject (see
+	// RenameIfNotExists below), and a backend that ignores it on
+	// PutObject makes every single-winner assumption in the code
+	// base silently false (shared-DEK mint, backup lease, audit
+	// chain slots, repo-init HSREPO claim) — while the capability
+	// claim simultaneously DISABLES the read-back/warning
+	// mitigations built for honest-false backends. So: with an
+	// ?endpoint= override the plugin reports ConditionalPut=false
+	// unless the operator explicitly vouches for the endpoint with
+	// ?conditional_put=native (MinIO ≥ RELEASE.2024-* and Cloudflare
+	// R2 do enforce it).
+	conditionalPut := endpoint == "" || q.Get("conditional_put") == "native"
+	switch q.Get("conditional_put") {
+	case "", "native":
+	default:
+		return fmt.Errorf("s3: unknown conditional_put=%q (want \"native\" or omit)", q.Get("conditional_put"))
+	}
 
 	// Per-request HTTP timeout. The SDK's default HTTPClient has
 	// no overall timeout; combined with TCP keepalive's
@@ -193,6 +225,7 @@ func (p *Plugin) Open(ctx context.Context, cfg storage.StorageConfig) error {
 	p.prefix = prefix
 	p.storageClass = storageClass
 	p.region = awsCfg.Region
+	p.conditionalPut = conditionalPut
 	return nil
 }
 
@@ -230,7 +263,7 @@ func (p *Plugin) fullKey(key string) string {
 func (p *Plugin) Capabilities() storage.Capabilities {
 	return storage.Capabilities{
 		WORM:                   true,
-		ConditionalPut:         true,
+		ConditionalPut:         p.conditionalPut,
 		Multipart:              true,
 		ServerSideEncryption:   true,
 		CrossRegionReplicate:   true,

--- a/internal/plugin/storage/s3/s3_test.go
+++ b/internal/plugin/storage/s3/s3_test.go
@@ -424,8 +424,15 @@ func TestS3_PluginName(t *testing.T) {
 func TestS3_Capabilities(t *testing.T) {
 	p := &s3.Plugin{}
 	c := p.Capabilities()
-	if !c.WORM || !c.ConditionalPut || !c.Multipart {
-		t.Errorf("expected capabilities to advertise WORM/ConditionalPut/Multipart; got %+v", c)
+	if !c.WORM || !c.Multipart {
+		t.Errorf("expected capabilities to advertise WORM/Multipart; got %+v", c)
+	}
+	// ConditionalPut is endpoint-dependent since the honesty fix:
+	// true for AWS proper, false for unvouched ?endpoint= overrides.
+	// See TestCapabilities_ConditionalPutHonesty for the full matrix;
+	// an unopened plugin reports false (fail-safe).
+	if c.ConditionalPut {
+		t.Errorf("unopened plugin must not claim ConditionalPut; got %+v", c)
 	}
 }
 

--- a/internal/repo/init.go
+++ b/internal/repo/init.go
@@ -181,28 +181,45 @@ func Open(ctx context.Context, url string) (*Metadata, storage.StoragePlugin, er
 	// as RepoFormatV1_0 (the only format this binary writes today).
 	// The check is the load-bearing part of the test scenario at
 	// test/scenarios/L4_repo_format_forward_check.scenario.yaml.
-	if rvc, rvErr := sp.Get(ctx, RepoVersionFilename); rvErr == nil {
-		rvBody, _ := stdio.ReadAll(rvc)
-		_ = rvc.Close()
-		var rv RepoVersion
-		if err := json.Unmarshal(rvBody, &rv); err != nil {
-			_ = sp.Close()
-			return nil, nil, fmt.Errorf("repo: parse %s: %w", RepoVersionFilename, err)
-		}
-		known := false
-		for _, f := range SupportedRepoFormats {
-			if rv.Format == f {
-				known = true
-				break
-			}
-		}
-		if !known {
-			_ = sp.Close()
-			return nil, nil, &ErrRepoFormatUnsupported{Format: rv.Format, Supported: SupportedRepoFormats}
-		}
+	if err := checkRepoFormat(ctx, sp); err != nil {
+		_ = sp.Close()
+		return nil, nil, err
 	}
 
 	return &meta, sp, nil
+}
+
+// checkRepoFormat enforces the forward-format gate. FAIL-CLOSED error
+// handling: only a definitive ErrNotFound may take the "no marker =
+// v1.0" path. Any other Get failure (throttling, IAM denial,
+// partition) must fail Open — treating it like absence let an old
+// binary skip the gate on a FUTURE-format repo and mutate it under
+// stale assumptions (its lenient readers skip unparseable v2
+// manifests as "malformed", so a `repo gc --apply` would reap chunks
+// those manifests still reference).
+func checkRepoFormat(ctx context.Context, sp storage.StoragePlugin) error {
+	rvc, rvErr := sp.Get(ctx, RepoVersionFilename)
+	if rvErr != nil {
+		if errors.Is(rvErr, storage.ErrNotFound) {
+			return nil // pre-v0.10 repo: no marker, implicitly v1.0
+		}
+		return fmt.Errorf("repo: read %s (refusing to assume the repo format): %w", RepoVersionFilename, rvErr)
+	}
+	rvBody, readErr := stdio.ReadAll(rvc)
+	_ = rvc.Close()
+	if readErr != nil {
+		return fmt.Errorf("repo: read %s body: %w", RepoVersionFilename, readErr)
+	}
+	var rv RepoVersion
+	if err := json.Unmarshal(rvBody, &rv); err != nil {
+		return fmt.Errorf("repo: parse %s: %w", RepoVersionFilename, err)
+	}
+	for _, f := range SupportedRepoFormats {
+		if rv.Format == f {
+			return nil
+		}
+	}
+	return &ErrRepoFormatUnsupported{Format: rv.Format, Supported: SupportedRepoFormats}
 }
 
 // ErrRepoFormatUnsupported is returned by Open when the repo's

--- a/internal/repo/open_version_gate_test.go
+++ b/internal/repo/open_version_gate_test.go
@@ -1,0 +1,76 @@
+package repo
+
+import (
+	"context"
+	"errors"
+	"io"
+	"net/url"
+	"strings"
+	"testing"
+
+	"github.com/cybertec-postgresql/pg_hardstorage/internal/plugin/storage"
+	"github.com/cybertec-postgresql/pg_hardstorage/internal/plugin/storage/fs"
+)
+
+// flakyGetSP fails Get for one specific key with a NON-NotFound error
+// (throttle/partition/IAM-denial shape).
+type flakyGetSP struct {
+	storage.StoragePlugin
+	failKey string
+}
+
+func (f *flakyGetSP) Get(ctx context.Context, key string) (io.ReadCloser, error) {
+	if key == f.failKey {
+		return nil, errors.New("simulated transient storage error (503)")
+	}
+	return f.StoragePlugin.Get(ctx, key)
+}
+
+// The forward-format gate used to run ONLY when the _repo_version.json
+// Get succeeded: every other failure mode (throttling, partition, IAM
+// deny on that one key) was treated like "marker absent = v1.0" and
+// Open proceeded — letting an old binary mutate a future-format repo
+// whose v2 manifests its lenient readers skip as "malformed", so a
+// routine `repo gc --apply` would reap chunks those manifests still
+// reference. The gate must be fail-closed: only a definitive
+// ErrNotFound may take the legacy path.
+func TestCheckRepoFormat_FailsClosedOnTransientReadError(t *testing.T) {
+	root := t.TempDir()
+	if _, err := Init(context.Background(), InitOptions{URL: "file://" + root}); err != nil {
+		t.Fatal(err)
+	}
+	inner := &fs.Plugin{}
+	if err := inner.Open(context.Background(), storage.StorageConfig{
+		URL: &url.URL{Scheme: "file", Path: root},
+	}); err != nil {
+		t.Fatal(err)
+	}
+	t.Cleanup(func() { _ = inner.Close() })
+
+	err := checkRepoFormat(context.Background(),
+		&flakyGetSP{StoragePlugin: inner, failKey: RepoVersionFilename})
+	if err == nil {
+		t.Fatal("format gate passed despite an undeterminable repo format — fail-open")
+	}
+	if !strings.Contains(err.Error(), RepoVersionFilename) {
+		t.Errorf("error should name the version marker; got: %v", err)
+	}
+
+	// Definitive absence (legacy pre-v0.10 repo) must still pass.
+	if err := inner.Delete(context.Background(), RepoVersionFilename); err != nil {
+		t.Fatal(err)
+	}
+	if err := checkRepoFormat(context.Background(), inner); err != nil {
+		t.Errorf("legacy repo without a version marker must pass the gate, got: %v", err)
+	}
+
+	// A future format must still refuse (the gate's original job).
+	if _, err := inner.Put(context.Background(), RepoVersionFilename,
+		strings.NewReader(`{"schema":"pg_hardstorage.repo_version.v1","format":"v9.9"}`), storage.PutOptions{}); err != nil {
+		t.Fatal(err)
+	}
+	var unsup *ErrRepoFormatUnsupported
+	if err := checkRepoFormat(context.Background(), inner); !errors.As(err, &unsup) {
+		t.Errorf("future format v9.9: err = %v, want ErrRepoFormatUnsupported", err)
+	}
+}

--- a/internal/repo/sharedkey/sharedkey.go
+++ b/internal/repo/sharedkey/sharedkey.go
@@ -18,6 +18,7 @@ import (
 	"bytes"
 	"context"
 	"crypto/sha256"
+	"crypto/subtle"
 	"encoding/base64"
 	"encoding/hex"
 	"encoding/json"
@@ -172,7 +173,18 @@ func ResolveOrMint(ctx context.Context, sp storage.StoragePlugin, kekRef string,
 
 	// 1. Authoritative object.
 	if wrapped, ok := readWrappedDEK(ctx, sp, key, kekRef); ok {
-		return unwrapInto(wrapped, unwrap)
+		out, err := unwrapInto(wrapped, unwrap)
+		if err != nil || out.Have {
+			return out, err
+		}
+		// Present but won't unwrap under this KEK — e.g. a stale
+		// object left behind by a KEK rotation that predated
+		// Rewrap(). Freshly-ROTATED manifests wrap the SAME shared
+		// DEK under the current KEK, so fall through to the manifest
+		// scan and adopt from there instead of hard-failing every
+		// future backup on an internal object the operator has never
+		// heard of. If the scan also finds only unusable candidates,
+		// it returns UnusableCandidate exactly as before.
 	}
 
 	// 2. Legacy seed: adopt an existing manifest DEK.
@@ -190,9 +202,16 @@ func ResolveOrMint(ctx context.Context, sp storage.StoragePlugin, kekRef string,
 		// Best-effort promotion so future writers skip the manifest scan
 		// and, more importantly, so a later concurrent fresh-mint can't
 		// race in a divergent DEK. A conflict here is fine — someone else
-		// adopted the same manifest DEK.
+		// adopted the same manifest DEK. When a STALE object occupies the
+		// slot (rotation leftover that won't unwrap under this KEK),
+		// replace it: the adopted DEK is proven against a committed
+		// manifest, the stale wrap is provably useless to this KEK.
 		if wrapped, werr := wrap(out.DEK); werr == nil {
-			_ = putSharedDEK(ctx, sp, key, kekRef, wrapped)
+			if perr := putSharedDEK(ctx, sp, key, kekRef, wrapped); errors.Is(perr, storage.ErrAlreadyExists) {
+				if existing, ok := readWrappedDEK(ctx, sp, key, kekRef); !ok || !unwrapsToSame(existing, unwrap, out.DEK) {
+					_ = putSharedDEKOverwrite(ctx, sp, key, kekRef, wrapped)
+				}
+			}
 		}
 		return out, nil
 	}
@@ -315,4 +334,87 @@ func readWrappedDEK(ctx context.Context, sp storage.StoragePlugin, key, wantKEKR
 		return nil, false
 	}
 	return wrapped, true
+}
+
+// unwrapsToSame reports whether wrapped unwraps (under the caller's
+// KEK) to exactly dek. Used to decide whether an occupied shared-DEK
+// slot already holds the right key material.
+func unwrapsToSame(wrapped []byte, unwrap Unwrapper, dek [encryption.KeyLen]byte) bool {
+	got, err := unwrap(wrapped)
+	if err != nil || len(got) != encryption.KeyLen {
+		return false
+	}
+	return subtle.ConstantTimeCompare(got, dek[:]) == 1
+}
+
+// putSharedDEKOverwrite unconditionally replaces the shared-DEK
+// envelope at key. Reserved for repairing a slot that holds a wrap
+// PROVEN unusable under the caller's KEK (rotation leftovers) — the
+// normal mint path must keep using the IfNotExists variant so
+// concurrent first-writers still converge on a single winner.
+func putSharedDEKOverwrite(ctx context.Context, sp storage.StoragePlugin, key, kekRef string, wrapped []byte) error {
+	body, err := json.Marshal(manifestEnvelope{Encryption: &envelope{
+		Scheme:     Scheme,
+		KEKRef:     kekRef,
+		WrappedDEK: base64.StdEncoding.EncodeToString(wrapped),
+	}})
+	if err != nil {
+		return err
+	}
+	_, err = sp.Put(ctx, key, bytes.NewReader(body), storage.PutOptions{
+		ContentLength: int64(len(body)),
+	})
+	return err
+}
+
+// Rewrap migrates the authoritative shared-DEK object across a KEK
+// rotation: it unwraps the shared DEK recorded under oldRef, rewraps
+// it under the new KEK, publishes it at newRef's slot, and removes
+// the old slot. Without this, `kms rotate` rewrapped every manifest
+// but left the shared-DEK object under the retired KEK — the next
+// backup's ResolveOrMint found an object it could not unwrap and
+// every subsequent backup and `wal stream` hard-failed until the
+// operator deleted an undocumented internal object.
+//
+// Returns (false, nil) when oldRef has no object to migrate (legacy
+// repo or never-encrypted): the manifest-scan adoption path covers
+// those.
+// removeOld controls whether oldRef's slot is deleted after the new
+// slot is published — pass false when aliasing the same DEK to an
+// additional ref (e.g. keeping "local:default" resolvable after a
+// local rotation) so the source slot survives.
+func Rewrap(ctx context.Context, sp storage.StoragePlugin, oldRef, newRef string, unwrapOld Unwrapper, wrapNew Wrapper, removeOld bool) (bool, error) {
+	wrapped, ok := readWrappedDEK(ctx, sp, sharedDEKKey(oldRef), oldRef)
+	if !ok {
+		return false, nil
+	}
+	dekBytes, err := unwrapOld(wrapped)
+	if err != nil {
+		return false, fmt.Errorf("sharedkey rewrap: unwrap %s object with old KEK: %w", oldRef, err)
+	}
+	if len(dekBytes) != encryption.KeyLen {
+		return false, fmt.Errorf("sharedkey rewrap: unwrapped DEK has length %d (want %d)", len(dekBytes), encryption.KeyLen)
+	}
+	var dek [encryption.KeyLen]byte
+	copy(dek[:], dekBytes)
+
+	newWrapped, err := wrapNew(dek)
+	if err != nil {
+		return false, fmt.Errorf("sharedkey rewrap: wrap under new KEK: %w", err)
+	}
+	newKey := sharedDEKKey(newRef)
+	// Overwrite semantics: rotation is an operator-driven maintenance
+	// action and the new slot may hold a stale leftover from an
+	// earlier partial rotation; the DEK content is the invariant
+	// (same DEK, new wrap), so replacing is always safe here.
+	if err := putSharedDEKOverwrite(ctx, sp, newKey, newRef, newWrapped); err != nil {
+		return false, fmt.Errorf("sharedkey rewrap: publish %s object: %w", newRef, err)
+	}
+	if oldKey := sharedDEKKey(oldRef); removeOld && oldKey != newKey {
+		// Best-effort: a surviving old object is harmless once the new
+		// slot exists (nothing resolves the retired ref), but tidy it
+		// so a future rotation back to this ref can't find a stale wrap.
+		_ = sp.Delete(ctx, oldKey)
+	}
+	return true, nil
 }

--- a/internal/testkit/sink/minio.go
+++ b/internal/testkit/sink/minio.go
@@ -261,7 +261,7 @@ func (m *minioRuntime) Down(ctx context.Context) error {
 // MinIO (and any non-AWS S3 endpoint) — vhost-style addressing
 // would try to dial bucket.127.0.0.1, which doesn't resolve.
 func (m *minioRuntime) URL() string {
-	return fmt.Sprintf("s3://%s?endpoint=http://127.0.0.1:%d&path_style=true&region=us-east-1",
+	return fmt.Sprintf("s3://%s?endpoint=http://127.0.0.1:%d&path_style=true&region=us-east-1&conditional_put=native",
 		m.bucket, m.port)
 }
 

--- a/internal/testkit/sink/tls_minio.go
+++ b/internal/testkit/sink/tls_minio.go
@@ -310,7 +310,7 @@ func (m *tlsMinioRuntime) Down(ctx context.Context) error {
 // the SDK upgrades to TLS automatically when the scheme is
 // https.
 func (m *tlsMinioRuntime) URL() string {
-	return fmt.Sprintf("s3://%s?endpoint=https://127.0.0.1:%d&path_style=true&region=us-east-1",
+	return fmt.Sprintf("s3://%s?endpoint=https://127.0.0.1:%d&path_style=true&region=us-east-1&conditional_put=native",
 		m.bucket, m.port)
 }
 

--- a/internal/verify/sandbox/backend_docker.go
+++ b/internal/verify/sandbox/backend_docker.go
@@ -104,7 +104,7 @@ func (dockerBackend) Verify(ctx context.Context, opts Options) (*Result, error) 
 		res.Passed = true
 		return res, nil
 	}
-	if isMissingManifestError(stderr) {
+	if classifySkip(stderr, opts.ManifestCaptured) {
 		res.Skipped = true
 		res.SkipReason = "backup_manifest absent (pg_basebackup-style manifest was not captured)"
 		return res, nil

--- a/internal/verify/sandbox/classify_skip_test.go
+++ b/internal/verify/sandbox/classify_skip_test.go
@@ -1,0 +1,26 @@
+package sandbox
+
+import "testing"
+
+// A pg_verifybackup "could not open .../backup_manifest" used to be
+// classified as a benign skip UNCONDITIONALLY — including when the
+// caller had just written backup_manifest into the datadir and the
+// sandbox simply couldn't see it (bad bind-mount, remote DOCKER_HOST
+// mounting a nonexistent host path as an empty dir, permissions).
+// verify --full then exited 0 with a fabricated "manifest was not
+// captured" reason, and scheduled verification stayed green while
+// verifying nothing.
+func TestClassifySkip_ManifestCapturedIsNeverASkip(t *testing.T) {
+	missing := `pg_verifybackup: error: could not open file "/var/lib/postgresql/data/backup_manifest": No such file or directory`
+
+	if classifySkip(missing, true) {
+		t.Error("caller captured a manifest but the sandbox can't see it — that is an environment FAILURE, classified as benign skip")
+	}
+	if !classifySkip(missing, false) {
+		t.Error("genuinely-uncaptured manifest should remain a benign skip")
+	}
+	// A non-manifest failure is never a skip regardless of capture.
+	if classifySkip("pg_verifybackup: error: checksum mismatch in file \"base/1/1259\"", false) {
+		t.Error("checksum mismatch misclassified as skip")
+	}
+}

--- a/internal/verify/sandbox/sandbox.go
+++ b/internal/verify/sandbox/sandbox.go
@@ -175,6 +175,16 @@ type Options struct {
 	// result if it doesn't.
 	DataDir string
 
+	// ManifestCaptured tells the backend the caller ACTUALLY wrote
+	// backup_manifest into DataDir. When true, a pg_verifybackup
+	// "could not open .../backup_manifest" failure is a REAL failure
+	// (bad bind-mount, remote DOCKER_HOST seeing a different
+	// filesystem, permissions), never a benign skip — classifying it
+	// as "manifest was not captured" fabricated an exit-0 "verified"
+	// out of an environment fault and let verification cadence rot
+	// silently behind green dashboards.
+	ManifestCaptured bool
+
 	// PGMajor is the major version of the source PG ("15",
 	// "16", "17").  The Docker image / Firecracker rootfs
 	// must match so the pg_verifybackup binary's protocol
@@ -337,6 +347,17 @@ func Verify(ctx context.Context, opts Options) (*Result, error) {
 	}
 
 	return b.Verify(ctx, resolved)
+}
+
+// classifySkip decides whether a non-zero pg_verifybackup exit is a
+// benign "no manifest was ever captured" skip. It is a skip ONLY
+// when the stderr matches the missing-manifest pattern AND the
+// caller did not capture a manifest — when the caller wrote
+// backup_manifest into the datadir, the same stderr means the
+// sandbox could not see the caller's files (bad mount, remote
+// docker daemon, permissions), which must fail, not skip.
+func classifySkip(stderr string, manifestCaptured bool) bool {
+	return isMissingManifestError(stderr) && !manifestCaptured
 }
 
 // isMissingManifestError detects the specific stderr pattern


### PR DESCRIPTION
Round two of the corruption hunt: two fresh audit passes (restore/rotate/tarsink and S3/init/manifest — areas round one didn't cover) plus the evidenced backlog from round one. Eight fixes, each with a regression test; full `-race` gate green.

| # | Bug | Class | Fix |
|---|-----|-------|-----|
| 1 | **KEK rotation could permanently destroy backups** — manifest rewrite was Put-tmp → DELETE → rename; a rename failure deleted the tmp "as cleanup", the backup vanished from GC's reference walk, and the next sweep reaped its chunks | Corruption | Single atomic overwrite — a valid manifest body exists at the key at every instant. `TestRotateKEK_FailedRewriteNeverLosesTheManifest` |
| 2 | **KEK rotation bricked the repo** — shared-DEK object left under the retired KEK (every future backup + `wal stream` hard-failed), and `local:v2`-style refs on rotated manifests resolved nowhere (all rotated backups unrestorable) | Availability | `RotateKEK` migrates the shared-DEK object (same DEK, new wrap) incl. the `local:default` alias; `ResolveOrMint` falls through to the manifest scan on an un-unwrappable object; both resolvers accept any `local:*` ref. 3 new tests |
| 3 | **`backup undelete` resurrects an incremental over a tombstoned parent** — live-listing but unrestorable; permanent loss after GC grace | Availability | Chain walk in `Undelete`, structured refusal naming the dead ancestor. `TestUndelete_RefusesWhenAncestorTombstoned` |
| 4 | **Forward-format gate failed OPEN on transient read errors** — throttle/IAM-deny on `_repo_version.json` was treated as "no marker = v1.0"; an old binary could gc a future-format repo | Corruption | Fail-closed `checkRepoFormat`; only `ErrNotFound` takes the legacy path. `TestCheckRepoFormat_FailsClosedOnTransientReadError` |
| 5 | **`Manifest.Validate` accepted unrestorable chain shapes** — incremental with empty/self parent, unknown/empty type, zero timeline all committed green | Corruption | Type/parent/timeline invariants at the commit gate. `TestManifestValidate_ChainInvariants` |
| 6 | **S3 claimed `ConditionalPut: true` for every endpoint** — the claim disables the audit read-back and lease-warning mitigations on S3-compatibles that may ignore `If-None-Match` (the harness already caught MinIO ignoring it on CopyObject) | Corruption | Custom `?endpoint=` reports false unless `?conditional_put=native`; AWS proper stays true; MinIO fixtures vouch explicitly. `TestCapabilities_ConditionalPutHonesty` |
| 7 | **`verify --full` fabricated "skipped" (exit 0) from environment failures** when the sandbox couldn't see a manifest the caller had just written | Honesty | `classifySkip` gated on manifest capture; captured-but-invisible is a real failure. `TestClassifySkip_ManifestCapturedIsNeverASkip` |
| 8 | **No-durability backends (sftp/scp) accepted silently** — power loss can tear chunks under a committed manifest, or lose WAL the slot advanced past | Corruption | Loud `durability_unenforceable` warnings in the backup runner and `wal stream` |

Remaining backlog (documented in CHANGELOG for round 3): timeline-history archival in plain `wal stream`, backup WAL-range coverage validation, restore-resume re-validation after host crash, legal-hold chain-aware retention filtering, type-aware capacity projection, `.deferred-*` staging reaper, shared-DEK nonce budget.