### PR TITLE
fix: nine more corruption / backup-availability bugs (hunt round 3)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,69 @@ keeps reading that version for at least 24 months after a successor lands.
 
 ## [Unreleased]
 
+### Corruption hunt, round three: nine more fixes
+
+Fresh audits of replication/heal/standby/timetravel and the audit
+chain / control plane / config layers, plus the remaining round-two
+backlog:
+
+- **Audit chain: a stale head pointer could silently destroy a
+  committed event.** The pointer update after an Append is
+  best-effort; a crash left it stale-but-valid, the next Append
+  recomputed the same sequence, and on a no-conditional-put backend
+  its Put overwrote the committed event — with the replacement linking
+  PrevHash correctly, so even `VerifyChain` stayed green. Append now
+  probes the slot first and relinks instead of writing.
+- **`audit verify-anchor` cried tamper on healthy repos.** It resolved
+  the anchored event by list index == sequence, which breaks under
+  mixed key layouts and WORM retention pruning. Resolution is now by
+  parsed sequence.
+- **Config drop-in overlays silently dropped retention, TDE,
+  audit-anchor, SLO, residency, and classification** for any
+  deployment defined in two files — the operator's `keep_monthly: 60`
+  drop-in vanished and rotate pruned with the default policy.
+  `mergeDeployment` now carries every field, with a reflection canary
+  test that fails when a future field lacks a merge arm.
+- **Replication committed manifests to the replica over missing or
+  failed chunks** — a DR replica that lies about restorability,
+  permanently invisible to `replicate verify` once the source copy is
+  GC'd. Manifests (backup and WAL) are now withheld unless every
+  referenced chunk landed.
+- **Timetravel with an LSN target always picked the newest backup**,
+  so every historical-LSN session failed at the restore reachability
+  gate (PG cannot rewind) — the feature's primary use case was
+  inoperative. The picker now selects the latest backup with
+  `StopLSN <= target`.
+- **A hold on an incremental wedged retention for the whole
+  deployment**: the held child left the delete batch, its parent
+  stayed in, and the chain guard refused the entire batch — every
+  scheduled rotate deleted nothing for the hold's lifetime. The hold
+  filter is now chain-aware (ancestors kept as `held_chain_anchor`,
+  the rest of the sweep proceeds).
+- **The pre-backup ENOSPC gate projected from the latest manifest
+  regardless of type**: weekly fulls were projected at the daily
+  incremental's size (gate false-passes, full dies mid-run on ENOSPC)
+  and incrementals at the full's size (cheap scheduled backups falsely
+  refused). Projection is now type-aware.
+- **Restore resume trusted the checkpoint blindly**: after an OS
+  crash the checkpoint can claim files the filesystem lost (parent
+  dirs were never dir-fsynced), yielding a datadir with missing
+  relation files — silent for TDE/pre-manifest sources, a wedged
+  retry loop otherwise. Resume now stats each claimed file against
+  its manifest size and re-materialises on mismatch.
+- **Timeline-history capture on failover was one-shot**: a transient
+  error during the unrepeatable promotion window skipped both the
+  capture and the backfill, silently capping
+  `recovery_target_timeline=latest` at the previous timeline in
+  streaming-only HA. Capture now retries with backoff, escalates to
+  CRITICAL on final failure, and no longer blocks the backfill.
+
+Still documented for a future round: heal's plaintext re-verify
+ordering on partial heals, control-plane job requeue after lost
+claims, backup WAL-range coverage validation, timeline-history
+archival in plain `wal stream`, `.deferred-*` staging reaper,
+shared-DEK nonce budget.
+
 ### Corruption hunt, round two: eight more fixes
 
 A second audit round (restore/rotate/tarsink, S3/init/manifest, plus

--- a/internal/audit/append_noconditional_test.go
+++ b/internal/audit/append_noconditional_test.go
@@ -3,6 +3,9 @@ package audit
 import (
 	"bytes"
 	"context"
+	"encoding/json"
+	"errors"
+	"fmt"
 	"io"
 	"net/url"
 	"strings"
@@ -117,4 +120,91 @@ func TestAppend_NoConditionalPut_ReadBackDetectsLostSlot(t *testing.T) {
 	if !strings.Contains(joined, "mine.event") {
 		t.Error("OUR event was silently lost (pre-fix behavior): read-back did not detect the stomped slot")
 	}
+}
+
+// headPointerDropSP drops writes to the head pointer once (crash
+// simulator: the event committed, the pointer update was lost) on an
+// otherwise-overwriting no-conditional-put backend.
+type headPointerDropSP struct {
+	storage.StoragePlugin
+	dropped bool
+}
+
+func (h *headPointerDropSP) Capabilities() storage.Capabilities {
+	return storage.Capabilities{ConditionalPut: false}
+}
+
+func (h *headPointerDropSP) Put(ctx context.Context, key string, r io.Reader, opts storage.PutOptions) (storage.PutResult, error) {
+	if !h.dropped && strings.HasSuffix(key, "_head.json") {
+		h.dropped = true
+		return storage.PutResult{}, errors.New("simulated head-pointer write failure")
+	}
+	opts.IfNotExists = false // last-writer-wins backend
+	return h.StoragePlugin.Put(ctx, key, r, opts)
+}
+
+// Regression: a STALE-but-valid head pointer (event committed, pointer
+// update lost) made the next Append target an occupied slot; on a
+// no-conditional-put backend the Put destroyed the committed event —
+// and the replacement linked PrevHash correctly, so VerifyChain stayed
+// green. Append must probe the slot first and relink instead.
+func TestAppend_NoConditionalPut_StaleHeadDoesNotOverwriteTail(t *testing.T) {
+	dir := t.TempDir()
+	inner := &fs.Plugin{}
+	if err := inner.Open(context.Background(), storage.StorageConfig{URL: &url.URL{Scheme: "file", Path: dir}}); err != nil {
+		t.Fatal(err)
+	}
+	defer inner.Close()
+	sp := &headPointerDropSP{StoragePlugin: inner}
+	store := NewStore(sp)
+	ctx := context.Background()
+
+	append1 := func(action string) {
+		t.Helper()
+		if err := store.Append(ctx, &Event{Action: action, Subject: Subject{Deployment: "db1"}}); err != nil {
+			t.Fatalf("append %s: %v", action, err)
+		}
+	}
+	append1("backup.committed") // seq 0
+	append1("backup.delete")    // seq 1 — head-pointer write DROPPED (stale at seq 0)
+	append1("kms.rotate")       // pre-fix: overwrote seq 1's committed event
+
+	actions := map[string]bool{}
+	count := 0
+	var shapes []string
+	for info, lerr := range inner.List(ctx, "audit/") {
+		if lerr != nil {
+			t.Fatal(lerr)
+		}
+		if !strings.HasSuffix(info.Key, ".json") || strings.HasSuffix(info.Key, "_head.json") {
+			continue
+		}
+		ev, gerr := readEventForTest(ctx, inner, info.Key)
+		if gerr != nil {
+			t.Fatalf("read %s: %v", info.Key, gerr)
+		}
+		actions[ev.Action] = true
+		shapes = append(shapes, fmt.Sprintf("%d:%s", ev.Sequence, ev.Action))
+		count++
+	}
+	if count != 3 || !actions["backup.delete"] {
+		t.Fatalf("committed event destroyed by stale-head Append: have %v, want 3 events incl. backup.delete", shapes)
+	}
+	if res, err := store.VerifyChain(ctx); err != nil || !res.OK {
+		t.Fatalf("chain verify after stale-head appends: res=%+v err=%v", res, err)
+	}
+}
+
+// readEventForTest decodes one event object.
+func readEventForTest(ctx context.Context, sp storage.StoragePlugin, key string) (*Event, error) {
+	rc, err := sp.Get(ctx, key)
+	if err != nil {
+		return nil, err
+	}
+	defer rc.Close()
+	var ev Event
+	if err := json.NewDecoder(rc).Decode(&ev); err != nil {
+		return nil, err
+	}
+	return &ev, nil
 }

--- a/internal/audit/audit.go
+++ b/internal/audit/audit.go
@@ -443,6 +443,24 @@ func (s *Store) Append(ctx context.Context, ev *Event) error {
 			return err
 		}
 		key := keyFor(ev)
+		if !s.sp.Capabilities().ConditionalPut {
+			// Stale-head defense. The head pointer is best-effort: a
+			// crash after the event Put but before the pointer update
+			// leaves a stale-but-VALID pointer, so the next Append
+			// recomputes the same sequence and targets an occupied
+			// slot. On a no-conditional-put backend that Put would
+			// DESTROY the committed event — and the replacement links
+			// PrevHash correctly, so even VerifyChain stays green
+			// (invisible loss in the tamper-evident log). Probe the
+			// slot first and relink onto its occupant instead of
+			// writing. The post-Put read-back below still covers the
+			// concurrent-writer window between this probe and our Put.
+			if existing, gerr := s.getByKey(ctx, key); gerr == nil {
+				prevHash = existing.Hash
+				seq = existing.Sequence + 1
+				continue
+			}
+		}
 		putOpts := storage.PutOptions{
 			ContentLength: int64(len(body)),
 			IfNotExists:   true,
@@ -1086,14 +1104,38 @@ func (s *Store) VerifyAnchor(ctx context.Context, log TransparencyLog, logID str
 	if err != nil {
 		return res, err
 	}
-	if int64(len(keys)) <= a.HeadSequence {
-		res.Mismatch = fmt.Sprintf("local chain is shorter than the anchor (have %d events, anchor points at sequence %d)",
-			len(keys), a.HeadSequence)
+	// Resolve the anchored event BY SEQUENCE, never by list index.
+	// Index==sequence silently breaks in two documented realities:
+	// mixed key layouts (legacy date-bucketed keys sort lexically
+	// before flat hexSeq keys despite lower sequences) and WORM
+	// retention pruning (oldest events reaped while sequences climb).
+	// Both made VerifyAnchor cry tamper on healthy chains — the one
+	// tool whose job is telling "verified" from "tampered".
+	var anchoredKey string
+	var maxSeq int64 = -1
+	for _, k := range keys {
+		seq, ok := seqFromEventKey(k)
+		if !ok {
+			continue
+		}
+		if seq > maxSeq {
+			maxSeq = seq
+		}
+		if seq == a.HeadSequence {
+			anchoredKey = k
+		}
+	}
+	if anchoredKey == "" {
+		if maxSeq < a.HeadSequence {
+			res.Mismatch = fmt.Sprintf("local chain is shorter than the anchor (highest local sequence %d, anchor points at sequence %d)",
+				maxSeq, a.HeadSequence)
+		} else {
+			res.Mismatch = fmt.Sprintf("event at anchored sequence %d not found locally (chain extends to %d — the anchored event is missing)",
+				a.HeadSequence, maxSeq)
+		}
 		return res, nil
 	}
-	// The global chain's events are sequence-contiguous, and the keys
-	// sort in sequence order, so index = sequence (events are 0-indexed).
-	ev, err := s.getByKey(ctx, keys[a.HeadSequence])
+	ev, err := s.getByKey(ctx, anchoredKey)
 	if err != nil {
 		return res, err
 	}

--- a/internal/audit/transparency_test.go
+++ b/internal/audit/transparency_test.go
@@ -279,3 +279,52 @@ func TestSearch_IgnoresAnchorRecords(t *testing.T) {
 			len(events), events)
 	}
 }
+
+// VerifyAnchor used to index lexically-sorted keys BY SEQUENCE
+// (keys[HeadSequence]). WORM retention pruning reaps the oldest
+// events while sequences keep climbing, so on a pruned chain the
+// index was off by the reaped count — "local chain is shorter than
+// the anchor" / hash mismatches on perfectly healthy repos, i.e. the
+// tamper detector crying tamper. The anchored event must be resolved
+// by parsing sequences from the keys.
+func TestVerifyAnchor_SurvivesRetentionPrunedTail(t *testing.T) {
+	store, sp := newAuditStore(t)
+	ctx := context.Background()
+	for i := 0; i < 4; i++ {
+		if err := store.Append(ctx, &audit.Event{Action: "tick"}); err != nil {
+			t.Fatal(err)
+		}
+	}
+	log := audit.NewStorageBackedLog(sp)
+	a, err := store.Anchor(ctx, log, "")
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	// Simulate retention reaping the oldest event (sequence 0).
+	var oldest string
+	for info, lerr := range sp.List(ctx, "audit/") {
+		if lerr != nil {
+			t.Fatal(lerr)
+		}
+		if strings.HasSuffix(info.Key, ".json") && !strings.HasSuffix(info.Key, "_head.json") &&
+			!strings.Contains(info.Key, "_anchors") {
+			oldest = info.Key
+			break
+		}
+	}
+	if oldest == "" {
+		t.Fatal("no event key found")
+	}
+	if err := sp.Delete(ctx, oldest); err != nil {
+		t.Fatal(err)
+	}
+
+	res, err := store.VerifyAnchor(ctx, log, a.LogID)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !res.OK {
+		t.Errorf("VerifyAnchor reports tamper on a healthy retention-pruned chain: %+v", res)
+	}
+}

--- a/internal/cli/backup.go
+++ b/internal/cli/backup.go
@@ -617,7 +617,7 @@ func backupCapacityPreflight(ctx context.Context, opts runOptions, verifier *bac
 	}
 	defer sp.Close()
 
-	projected, err := projectedBytesFromDeployment(ctx, sp, opts.deployment, verifier)
+	projected, err := projectedBytesFromDeployment(ctx, sp, opts.deployment, verifier, opts.incrementalFrom != "")
 	if err != nil {
 		// "no committed backups" is the fresh-deployment
 		// case — silent pass. Other read failures (signature

--- a/internal/cli/capacity_preflight.go
+++ b/internal/cli/capacity_preflight.go
@@ -133,7 +133,7 @@ func runCapacityPreflight(cmd *cobra.Command, opts capacityPreflightOptions) err
 		if vErr != nil {
 			return vErr
 		}
-		projected, err = projectedBytesFromDeployment(cmd.Context(), sp, opts.fromDeployment, verifier)
+		projected, err = projectedBytesFromDeployment(cmd.Context(), sp, opts.fromDeployment, verifier, false)
 		if err != nil {
 			return err
 		}
@@ -185,30 +185,58 @@ func runCapacityPreflight(cmd *cobra.Command, opts capacityPreflightOptions) err
 	return d.Result(output.NewResult(cmd.CommandPath()).WithBody(body))
 }
 
-// projectedBytesFromDeployment returns the deployment's latest
-// committed manifest's logical bytes — the natural projection
-// for "would the next backup fit?". Empty deployment → error.
-// No backups → error (the operator hasn't set up a baseline
-// yet; explicit --projected-bytes is the right call).
-func projectedBytesFromDeployment(ctx context.Context, sp storage.StoragePlugin, deployment string, verifier *backup.Verifier) (int64, error) {
+// projectedBytesFromDeployment projects the next backup's logical
+// bytes from the deployment's history, TYPE-AWARE: a full run is
+// projected from the most recent NON-incremental manifest, an
+// incremental run from the most recent incremental (falling back to
+// latest-any). Blind latest-by-StoppedAt was wrong in both
+// directions on the standard daily-incremental/weekly-full cadence:
+// the Sunday full was projected at ~2% of its real size (latest =
+// Saturday's incremental) so the ENOSPC guard false-passed and the
+// full aborted mid-run hours later — and Monday's 5 GB incremental
+// was projected at the full 500 GB and could be falsely REFUSED on a
+// repo with ample space, silently blocking scheduled backups.
+//
+// List errors are no longer swallowed: if they prevented finding any
+// manifest, the caller sees the real problem instead of a silently
+// skipped gate.
+func projectedBytesFromDeployment(ctx context.Context, sp storage.StoragePlugin, deployment string, verifier *backup.Verifier, incremental bool) (int64, error) {
 	if deployment == "" {
 		return 0, output.NewError("usage.missing_arg",
 			"capacity preflight: --from-deployment requires a non-empty name").Wrap(output.ErrUsage)
 	}
 	store := backup.NewManifestStore(sp)
-	var latest *backup.Manifest
+	var latestAny, latestKind *backup.Manifest
+	var lastListErr error
 	for m, err := range store.List(ctx, deployment, verifier) {
 		if err != nil {
+			lastListErr = err
 			continue
 		}
 		if m == nil {
 			continue
 		}
-		if latest == nil || m.StoppedAt.After(latest.StoppedAt) {
-			latest = m
+		if latestAny == nil || m.StoppedAt.After(latestAny.StoppedAt) {
+			latestAny = m
+		}
+		matches := (m.Type == backup.BackupTypeIncremental) == incremental
+		if matches && (latestKind == nil || m.StoppedAt.After(latestKind.StoppedAt)) {
+			latestKind = m
 		}
 	}
-	if latest == nil {
+	pick := latestKind
+	if pick == nil {
+		// No same-kind history: fall back to latest-any. For a first
+		// incremental this over-projects (conservative); for a full
+		// in an incrementals-only repo it under-projects, but that
+		// shape cannot occur (incrementals need a full anchor).
+		pick = latestAny
+	}
+	if pick == nil {
+		if lastListErr != nil {
+			return 0, output.NewError("capacity.list_failed",
+				fmt.Sprintf("capacity preflight: could not read %s's manifests for a projection: %v", deployment, lastListErr)).Wrap(lastListErr)
+		}
 		return 0, output.NewError("notfound.backup",
 			fmt.Sprintf("capacity preflight: deployment %q has no committed backups; pass --projected-bytes explicitly", deployment)).
 			WithSuggestion(&output.Suggestion{
@@ -217,7 +245,7 @@ func projectedBytesFromDeployment(ctx context.Context, sp storage.StoragePlugin,
 			})
 	}
 	var total int64
-	for _, f := range latest.Files {
+	for _, f := range pick.Files {
 		total += f.Size
 	}
 	return total, nil

--- a/internal/cli/capacity_projection_test.go
+++ b/internal/cli/capacity_projection_test.go
@@ -1,0 +1,81 @@
+package cli
+
+import (
+	"context"
+	"net/url"
+	"testing"
+	"time"
+
+	"github.com/cybertec-postgresql/pg_hardstorage/internal/backup"
+	"github.com/cybertec-postgresql/pg_hardstorage/internal/plugin/storage"
+	"github.com/cybertec-postgresql/pg_hardstorage/internal/plugin/storage/fs"
+	"github.com/cybertec-postgresql/pg_hardstorage/internal/repo"
+	repoPkg "github.com/cybertec-postgresql/pg_hardstorage/internal/repo"
+)
+
+// The pre-backup ENOSPC gate projected the next backup from the
+// latest manifest BY TIMESTAMP, blind to Type. On the standard
+// daily-incremental / weekly-full cadence that meant: the weekly
+// FULL was projected at the incremental's ~2% size (gate
+// false-passes, backup aborts mid-run on ENOSPC hours later), and
+// the daily INCREMENTAL was projected at the full's size (gate
+// falsely REFUSES cheap backups on a repo with ample space).
+func TestProjectedBytes_TypeAware(t *testing.T) {
+	root := t.TempDir()
+	if _, err := repo.Init(context.Background(), repo.InitOptions{URL: "file://" + root}); err != nil {
+		t.Fatal(err)
+	}
+	sp := &fs.Plugin{}
+	if err := sp.Open(context.Background(), storage.StorageConfig{
+		URL: &url.URL{Scheme: "file", Path: root},
+	}); err != nil {
+		t.Fatal(err)
+	}
+	t.Cleanup(func() { _ = sp.Close() })
+
+	priv, pub, err := backup.GenerateKeypair(nil)
+	if err != nil {
+		t.Fatal(err)
+	}
+	signer, _ := backup.LoadSigner(priv)
+	verifier, _ := backup.LoadVerifier(pub)
+	store := backup.NewManifestStore(sp)
+
+	commit := func(id, parent string, btype backup.BackupType, size int64, ts time.Time) {
+		t.Helper()
+		m := &backup.Manifest{
+			Schema: backup.Schema, BackupID: id, Deployment: "db1",
+			Type: btype, ParentBackupID: parent,
+			PGVersion: 17, SystemIdentifier: "7000000000000000001",
+			StartLSN: "0/3000028", StopLSN: "0/30001A0", Timeline: 1,
+			StartedAt: ts.Add(-time.Minute), StoppedAt: ts,
+			BackupLabel: "START WAL LOCATION: 0/3000028\n",
+			Tablespaces: []backup.Tablespace{{OID: 1663, Location: "pg_default"}},
+			Files: []backup.FileEntry{{Path: "data/f", Size: size, Mode: 0o600,
+				Chunks: []backup.ChunkRef{{Hash: repoPkg.HashOf([]byte(id)), Offset: 0, Len: size}}}},
+		}
+		if err := store.Commit(context.Background(), m, signer, backup.CommitOptions{}); err != nil {
+			t.Fatalf("commit %s: %v", id, err)
+		}
+	}
+
+	// Sunday 500 MB full, then Saturday 5 MB incremental (newest).
+	commit("db1.full.20260719T020000Z.aaaa", "", backup.BackupTypeFull, 500<<20, time.Date(2026, 7, 19, 2, 0, 0, 0, time.UTC))
+	commit("db1.incr.20260725T020000Z.bbbb", "db1.full.20260719T020000Z.aaaa", backup.BackupTypeIncremental, 5<<20, time.Date(2026, 7, 25, 2, 0, 0, 0, time.UTC))
+
+	full, err := projectedBytesFromDeployment(context.Background(), sp, "db1", verifier, false)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if full != 500<<20 {
+		t.Errorf("full-run projection = %d, want %d (the full's size) — a small projection false-passes the ENOSPC gate and the weekly full dies mid-run", full, int64(500<<20))
+	}
+
+	incr, err := projectedBytesFromDeployment(context.Background(), sp, "db1", verifier, true)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if incr != 5<<20 {
+		t.Errorf("incremental-run projection = %d, want %d (the incremental's size) — over-projection falsely refuses cheap scheduled backups", incr, int64(5<<20))
+	}
+}

--- a/internal/cli/hold.go
+++ b/internal/cli/hold.go
@@ -569,11 +569,24 @@ func runHoldList(cmd *cobra.Command, scope, repoURL string) error {
 // without retention itself having to know about them. Returns the
 // kept-after-filter slice plus the deployment+backup-ids that were
 // blocked, so the rotate report can surface them as a separate stat.
-func filterHeld(ctx context.Context, store *backup.ManifestStore, deployment string, decisionDelete []*backup.Manifest) ([]*backup.Manifest, []string, error) {
+// The extra `all` parameter carries every manifest of the deployment
+// so the filter can be CHAIN-AWARE: a hold on an incremental must
+// also protect its ancestors. Without that, the held child stayed
+// out of the batch while its parent stayed IN — SoftDeleteBatch's
+// chain guard then refused the ENTIRE batch (live descendant not in
+// batch), so for the lifetime of the hold every scheduled
+// `rotate --apply` deleted NOTHING for the deployment: unbounded repo
+// and WAL growth that eventually threatens new backups, while the
+// dry-run report kept claiming a normal sweep.
+func filterHeld(ctx context.Context, store *backup.ManifestStore, deployment string, decisionDelete, all []*backup.Manifest) ([]*backup.Manifest, []string, []string, error) {
 	if len(decisionDelete) == 0 {
-		return decisionDelete, nil, nil
+		return decisionDelete, nil, nil, nil
 	}
-	keep := make([]*backup.Manifest, 0, len(decisionDelete))
+	byID := make(map[string]*backup.Manifest, len(all))
+	for _, m := range all {
+		byID[m.BackupID] = m
+	}
+	heldSet := make(map[string]bool)
 	var held []string
 	for _, m := range decisionDelete {
 		// IsActivelyHeld respects ExpiresAt: an expired hold
@@ -582,15 +595,39 @@ func filterHeld(ctx context.Context, store *backup.ManifestStore, deployment str
 		// an operator runs `hold remove` explicitly.
 		ok, err := store.IsActivelyHeld(ctx, deployment, m.BackupID)
 		if err != nil {
-			return nil, nil, fmt.Errorf("hold check %s: %w", m.BackupID, err)
+			return nil, nil, nil, fmt.Errorf("hold check %s: %w", m.BackupID, err)
 		}
 		if ok {
+			heldSet[m.BackupID] = true
 			held = append(held, m.BackupID)
-			continue
 		}
-		keep = append(keep, m)
 	}
-	return keep, held, nil
+	// Transitively protect every ancestor of a held backup so the
+	// remaining batch stays chain-consistent and deletable.
+	anchorSet := make(map[string]bool)
+	for id := range heldSet {
+		cur := byID[id]
+		for cur != nil && cur.ParentBackupID != "" {
+			pid := cur.ParentBackupID
+			if !heldSet[pid] && !anchorSet[pid] {
+				anchorSet[pid] = true
+			}
+			cur = byID[pid]
+		}
+	}
+	keep := make([]*backup.Manifest, 0, len(decisionDelete))
+	var anchors []string
+	for _, m := range decisionDelete {
+		switch {
+		case heldSet[m.BackupID]:
+			// already reported in held
+		case anchorSet[m.BackupID]:
+			anchors = append(anchors, m.BackupID)
+		default:
+			keep = append(keep, m)
+		}
+	}
+	return keep, held, anchors, nil
 }
 
 // Result body shapes — stable per the v1 schema commitment.

--- a/internal/cli/repo_replicate_test.go
+++ b/internal/cli/repo_replicate_test.go
@@ -491,7 +491,12 @@ func TestRepoReplicate_IncompleteExitsNonZero(t *testing.T) {
 	if exit == int(output.ExitOK) {
 		t.Fatalf("incomplete replication must exit non-zero; got OK\nstdout=%s", stdout)
 	}
-	if !strings.Contains(stdout+stderr, "repo.replicate.incomplete") {
-		t.Errorf("expected repo.replicate.incomplete:\nstdout=%s\nstderr=%s", stdout, stderr)
+	// Since manifests are withheld from the replica when any of their
+	// chunks fail to copy, this single-manifest fixture now surfaces
+	// as all_manifests_failed; either code is a correct non-zero
+	// refusal for an incomplete replication.
+	if !strings.Contains(stdout+stderr, "repo.replicate.incomplete") &&
+		!strings.Contains(stdout+stderr, "repo.replicate.all_manifests_failed") {
+		t.Errorf("expected an incomplete/all_manifests_failed refusal:\nstdout=%s\nstderr=%s", stdout, stderr)
 	}
 }

--- a/internal/cli/rotate.go
+++ b/internal/cli/rotate.go
@@ -153,20 +153,21 @@ func runRotate(cmd *cobra.Command, opts rotateOpts) error {
 		// effective 4." Without the filter, --apply would silently
 		// skip held backups (PutHold guards SoftDelete via the
 		// IsHeld check), but the dry-run number would lie.
-		filteredDelete, heldIDs, err := filterHeld(cmd.Context(), store, dep, decision.Delete)
+		filteredDelete, heldIDs, anchorIDs, err := filterHeld(cmd.Context(), store, dep, decision.Delete, manifests)
 		if err != nil {
 			return output.NewError("rotate.hold_check_failed",
 				fmt.Sprintf("rotate: %v", err)).Wrap(err)
 		}
 
 		report := rotationPerDeployment{
-			Deployment: dep,
-			Policy:     decision.PolicyName,
-			Kept:       len(decision.Keep) + len(heldIDs),
-			Deleted:    len(filteredDelete),
-			Held:       len(heldIDs),
-			HeldIDs:    heldIDs,
-			Decisions:  shapeDecisions(decision, heldIDs),
+			Deployment:      dep,
+			Policy:          decision.PolicyName,
+			Kept:            len(decision.Keep) + len(heldIDs) + len(anchorIDs),
+			Deleted:         len(filteredDelete),
+			Held:            len(heldIDs),
+			HeldIDs:         heldIDs,
+			HeldChainAnchor: anchorIDs,
+			Decisions:       shapeDecisions(decision, append(append([]string{}, heldIDs...), anchorIDs...)),
 		}
 
 		if opts.apply {
@@ -349,6 +350,10 @@ type rotationPerDeployment struct {
 	Deleted     int                `json:"deleted"`
 	Held        int                `json:"held,omitempty"`
 	HeldIDs     []string           `json:"held_ids,omitempty"`
+	// HeldChainAnchor lists backups kept ONLY because a held
+	// descendant depends on them — deleting them would either break
+	// the held chain or (pre-fix) wedge the whole batch.
+	HeldChainAnchor []string `json:"held_chain_anchor_ids,omitempty"`
 	Applied     int                `json:"applied,omitempty"`
 	HeldSkipped int                `json:"held_skipped,omitempty"`
 	Decisions   []rotationDecision `json:"decisions,omitempty"`

--- a/internal/cli/rotate_hold_chain_test.go
+++ b/internal/cli/rotate_hold_chain_test.go
@@ -1,0 +1,111 @@
+package cli_test
+
+import (
+	"context"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/cybertec-postgresql/pg_hardstorage/internal/backup"
+	"github.com/cybertec-postgresql/pg_hardstorage/internal/backup/keystore"
+	"github.com/cybertec-postgresql/pg_hardstorage/internal/paths"
+	"github.com/cybertec-postgresql/pg_hardstorage/internal/repo"
+)
+
+// A hold on an INCREMENTAL used to wedge retention for the whole
+// deployment: filterHeld removed the held child from the delete
+// batch but left its parent IN, SoftDeleteBatch's chain guard then
+// refused the entire batch ("live descendant not in batch"), and for
+// the lifetime of the hold every scheduled `rotate --apply` deleted
+// NOTHING — unbounded repo/WAL growth behind a dry-run report that
+// claimed a normal sweep. The filter must be chain-aware: protect
+// the held backup's ancestors and delete the rest.
+func TestRotate_HoldOnIncrementalDoesNotWedgeRetention(t *testing.T) {
+	repoURL := initRepoForTest(t)
+
+	now := time.Now().UTC()
+	_, sp, err := repo.Open(context.Background(), repoURL)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer sp.Close()
+	store := backup.NewManifestStore(sp)
+	p, err := paths.Resolve(paths.DefaultOptions())
+	if err != nil {
+		t.Fatal(err)
+	}
+	signer, _, err := keystore.LoadOrGenerate(p.Keyring.Value)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	plant := func(id, parent string, btype backup.BackupType, ts time.Time) {
+		t.Helper()
+		m := &backup.Manifest{
+			Schema:           backup.Schema,
+			BackupID:         id,
+			Deployment:       "db1",
+			Type:             btype,
+			ParentBackupID:   parent,
+			PGVersion:        170,
+			SystemIdentifier: "7388123",
+			StartLSN:         "0/0",
+			StopLSN:          "0/0",
+			Timeline:         1,
+			StartedAt:        ts.Add(-time.Minute),
+			StoppedAt:        ts,
+			BackupLabel:      "START WAL LOCATION: 0/0\n",
+			Tablespaces:      []backup.Tablespace{{OID: 1663, Location: "pg_default"}},
+			Files:            []backup.FileEntry{},
+		}
+		if err := store.Commit(context.Background(), m, signer, backup.CommitOptions{}); err != nil {
+			t.Fatalf("commit %s: %v", id, err)
+		}
+	}
+
+	// Old chain F←I1 (both policy-deletable), an unrelated old full G
+	// (deletable), and a fresh full R the policy keeps.
+	plant("F", "", backup.BackupTypeFull, now.Add(-40*24*time.Hour))
+	plant("I1", "F", backup.BackupTypeIncremental, now.Add(-39*24*time.Hour))
+	plant("G", "", backup.BackupTypeFull, now.Add(-35*24*time.Hour))
+	plant("R", "", backup.BackupTypeFull, now.Add(-1*time.Hour))
+
+	// Hold ONLY the incremental.
+	if _, _, exit := runCmd(t, "hold", "add", "db1", "I1",
+		"--repo", repoURL, "--reason", "litigation X-9"); exit != 0 {
+		t.Fatalf("hold add: exit %d", exit)
+	}
+
+	out, stderr, exit := runCmd(t,
+		"rotate", "db1", "--repo", repoURL,
+		"--policy", "simple", "--keep-for", "168h",
+		"--apply", "--output", "json",
+	)
+	if exit != 0 {
+		t.Fatalf("rotate --apply wedged by the held incremental (exit %d):\n%s%s", exit, out, stderr)
+	}
+
+	// G must be gone; F kept as chain anchor; I1 kept by the hold.
+	dead := func(id string) bool {
+		d, derr := store.IsTombstoned(context.Background(), "db1", id)
+		if derr != nil {
+			t.Fatal(derr)
+		}
+		return d
+	}
+	if !dead("G") {
+		t.Error("unrelated deletable full G was not tombstoned — retention still wedged")
+	}
+	if dead("F") {
+		t.Error("F tombstoned despite being the held chain's anchor")
+	}
+	if dead("I1") {
+		t.Error("held incremental I1 tombstoned")
+	}
+	if dead("R") {
+		t.Error("fresh keeper R tombstoned")
+	}
+	if !strings.Contains(out, "held_chain_anchor_ids") || !strings.Contains(out, `"F"`) {
+		t.Errorf("report should surface F as held_chain_anchor_ids:\n%s", out)
+	}
+}

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -838,5 +838,33 @@ func mergeDeployment(existing, overlay DeploymentConfig) DeploymentConfig {
 	if len(overlay.Patroni.Slots) > 0 {
 		existing.Patroni.Slots = overlay.Patroni.Slots
 	}
+	if overlay.Patroni.Interval != "" {
+		existing.Patroni.Interval = overlay.Patroni.Interval
+	}
+	// The fields below were previously NOT merged: a drop-in overlay
+	// that re-declared a deployment (the documented conf.d override
+	// pattern) silently DROPPED its retention / TDE / audit-anchor /
+	// SLO / residency / classification settings. Worst case was
+	// retention: the operator's keep_monthly:60 drop-in vanished and
+	// the scheduled rotate pruned with the default GFS policy —
+	// policy-mandated backups soft-deleted years early, silently.
+	if overlay.Schedule.AuditAnchor.Every != "" || overlay.Schedule.AuditAnchor.DailyAt != "" || overlay.Schedule.AuditAnchor.At != "" {
+		existing.Schedule.AuditAnchor = overlay.Schedule.AuditAnchor
+	}
+	if overlay.Retention != (RetentionConfig{}) {
+		existing.Retention = overlay.Retention
+	}
+	if overlay.TDE != (TDEConfig{}) {
+		existing.TDE = overlay.TDE
+	}
+	if overlay.SLO != (SLOConfig{}) {
+		existing.SLO = overlay.SLO
+	}
+	if len(overlay.Residency) > 0 {
+		existing.Residency = overlay.Residency
+	}
+	if overlay.Classification != "" {
+		existing.Classification = overlay.Classification
+	}
 	return existing
 }

--- a/internal/config/merge_completeness_test.go
+++ b/internal/config/merge_completeness_test.go
@@ -1,0 +1,70 @@
+package config
+
+import (
+	"reflect"
+	"testing"
+)
+
+// mergeDeployment used to copy only connection/repo/tenant/schedule
+// and drop everything else from an overlay that re-declared a
+// deployment (the documented conf.d override pattern): the
+// operator's retention drop-in vanished silently and the scheduled
+// rotate pruned with the DEFAULT policy — policy-mandated backups
+// soft-deleted years early. This test overlays a fully-populated
+// deployment onto a differently-populated base and asserts every
+// field comes out as the overlay's value, so a future field added to
+// DeploymentConfig without a merge arm fails here instead of
+// silently disappearing in production.
+func TestMergeDeployment_CarriesEveryField(t *testing.T) {
+	base := DeploymentConfig{
+		PGConnection:   "postgres://base@h/db",
+		Repo:           "file:///base",
+		Tenant:         "base",
+		Classification: "internal",
+	}
+	overlay := DeploymentConfig{
+		PGConnection: "postgres://over@h/db",
+		Repo:         "file:///over",
+		Tenant:       "over",
+		Schedule: DeploymentSchedule{
+			Backup:      ScheduleSpec{Every: "6h"},
+			Rotate:      ScheduleSpec{DailyAt: "04:00"},
+			Drill:       ScheduleSpec{DailyAt: "03:00"},
+			AuditAnchor: ScheduleSpec{Every: "30m"},
+		},
+		Retention:      RetentionConfig{Policy: "gfs", KeepDaily: 9, KeepWeekly: 8, KeepMonthly: 60, KeepYearly: 20, KeepFor: "720h", KeepFulls: 7},
+		Classification: "restricted",
+		Residency:      []string{"eu"},
+		SLO:            SLOConfig{RPOSeconds: 3600, RTOSeconds: 7200},
+		TDE:            TDEConfig{Enabled: true, Engine: "pg_tde", KeyRef: "ref-1"},
+		Patroni: PatroniConfig{
+			URL: "http://p:8008", User: "u", Password: "pw",
+			PasswordFile: "/pw", Slot: "s", Slots: []PatroniSlot{{Name: "a", Role: "leader"}},
+			Interval: "10s",
+		},
+	}
+
+	got := mergeDeployment(base, overlay)
+
+	if !reflect.DeepEqual(got, overlay) {
+		gv, ov := reflect.ValueOf(got), reflect.ValueOf(overlay)
+		tt := gv.Type()
+		for i := 0; i < tt.NumField(); i++ {
+			if !reflect.DeepEqual(gv.Field(i).Interface(), ov.Field(i).Interface()) {
+				t.Errorf("field %s dropped by mergeDeployment: got %+v, want %+v",
+					tt.Field(i).Name, gv.Field(i).Interface(), ov.Field(i).Interface())
+			}
+		}
+	}
+
+	// Completeness canary: if DeploymentConfig gains a field this
+	// test's overlay doesn't populate, force a look here. Every field
+	// of the overlay must be non-zero so the DeepEqual above actually
+	// exercises its merge arm.
+	ov := reflect.ValueOf(overlay)
+	for i := 0; i < ov.NumField(); i++ {
+		if ov.Field(i).IsZero() {
+			t.Errorf("test gap: overlay field %s is zero — populate it here AND add a merge arm in mergeDeployment", ov.Type().Field(i).Name)
+		}
+	}
+}

--- a/internal/repo/replicate.go
+++ b/internal/repo/replicate.go
@@ -355,12 +355,26 @@ func replicateManifest(ctx context.Context, src, dst storage.StoragePlugin, key,
 	}
 
 	// Chunks first — invariant: never a manifest at dst pointing at
-	// chunks that aren't.
+	// chunks that aren't. The invariant is ENFORCED, not aspirational:
+	// any chunk that failed to land at dst (missing at src, transient
+	// dst error) blocks the manifest Put. Previously the failures only
+	// bumped counters and the manifest committed anyway — a live,
+	// apparently-good backup on the DR replica that is not restorable,
+	// and (once the src copy is later GC'd) permanently invisible to
+	// `repo replicate verify`, which walks src listings only.
+	chunksOK := true
 	for _, h := range hashes {
 		if err := ctx.Err(); err != nil {
 			return
 		}
-		copyChunk(ctx, src, dst, h, opts, res)
+		if !copyChunk(ctx, src, dst, h, opts, res) {
+			chunksOK = false
+		}
+	}
+	if !chunksOK {
+		recordReplicateFailure(res, key, errors.New("manifest withheld from replica: one or more referenced chunks failed to copy (see chunk failures above); re-run replicate after fixing the source"))
+		res.ManifestsFailed++
+		return
 	}
 
 	// Then the manifest body itself.
@@ -396,11 +410,19 @@ func replicateWALManifest(ctx context.Context, src, dst storage.StoragePlugin, k
 		res.WALManifestsFailed++
 		return
 	}
+	chunksOK := true
 	for _, h := range hashes {
 		if err := ctx.Err(); err != nil {
 			return
 		}
-		copyChunk(ctx, src, dst, h, opts, res)
+		if !copyChunk(ctx, src, dst, h, opts, res) {
+			chunksOK = false
+		}
+	}
+	if !chunksOK {
+		recordReplicateFailure(res, key, errors.New("wal manifest withheld from replica: one or more referenced chunks failed to copy"))
+		res.WALManifestsFailed++
+		return
 	}
 	copyKey(ctx, src, dst, key, body, opts, res, walKind, false)
 }
@@ -503,7 +525,12 @@ func bumpKeyFailed(res *ReplicateResult, kind keyKind) {
 
 // copyChunk handles one chunk reference. Stats dst first (cheap),
 // pulls from src + writes to dst on miss. Updates res.
-func copyChunk(ctx context.Context, src, dst storage.StoragePlugin, h Hash, opts ReplicateOptions, res *ReplicateResult) {
+// copyChunk reports whether the chunk is DURABLY PRESENT at dst
+// after the call (copied, already there, or dry-run-would-copy).
+// Callers MUST NOT commit a manifest at dst unless every referenced
+// chunk returned true — a manifest over missing chunks is a DR
+// replica that lies about restorability.
+func copyChunk(ctx context.Context, src, dst storage.StoragePlugin, h Hash, opts ReplicateOptions, res *ReplicateResult) bool {
 	res.ChunksConsidered++
 	chunkKey := ChunkKey(h)
 
@@ -511,13 +538,13 @@ func copyChunk(ctx context.Context, src, dst storage.StoragePlugin, h Hash, opts
 	switch _, err := dst.Stat(ctx, chunkKey); {
 	case err == nil:
 		res.ChunksSkipped++
-		return
+		return true
 	case errors.Is(err, storage.ErrNotFound):
 		// fall through to copy
 	default:
 		recordReplicateFailure(res, chunkKey, fmt.Errorf("stat dst: %w", err))
 		res.ChunksFailed++
-		return
+		return false
 	}
 
 	// Pull from src.
@@ -528,12 +555,12 @@ func copyChunk(ctx context.Context, src, dst storage.StoragePlugin, h Hash, opts
 		// damage report.
 		recordReplicateFailure(res, chunkKey, fmt.Errorf("read src: %w", err))
 		res.ChunksMissing++
-		return
+		return false
 	}
 	if opts.DryRun {
 		res.ChunksCopied++
 		res.BytesCopied += int64(len(cb))
-		return
+		return true
 	}
 	putOpts := storage.PutOptions{IfNotExists: true, ContentLength: int64(len(cb))}
 	putOpts.RetainUntil, putOpts.RetentionMode = opts.retentionPut()
@@ -542,13 +569,16 @@ func copyChunk(ctx context.Context, src, dst storage.StoragePlugin, h Hash, opts
 	case err == nil:
 		res.ChunksCopied++
 		res.BytesCopied += int64(len(cb))
+		return true
 	case errors.Is(err, storage.ErrAlreadyExists):
 		// Race: a concurrent replicate run won the put. Treat as a
 		// skip — both copies have the same bytes (CAS contract).
 		res.ChunksSkipped++
+		return true
 	default:
 		recordReplicateFailure(res, chunkKey, fmt.Errorf("put dst: %w", err))
 		res.ChunksFailed++
+		return false
 	}
 }
 

--- a/internal/repo/replicate_test.go
+++ b/internal/repo/replicate_test.go
@@ -311,14 +311,22 @@ func TestReplicate_ChunkMissingAtSource(t *testing.T) {
 	if res.ChunksMissing != 1 {
 		t.Errorf("ChunksMissing=%d, want 1", res.ChunksMissing)
 	}
-	// The manifest still gets copied — broken-at-src is the source's
-	// problem, not ours; at least the replica will tell the same
-	// story.
-	if res.ManifestsCopied != 1 {
-		t.Errorf("ManifestsCopied=%d, want 1", res.ManifestsCopied)
+	// The manifest must be WITHHELD from the replica. The old
+	// posture ("broken-at-src is the source's problem — copy it
+	// anyway") produced a DR replica that lies: a live,
+	// apparently-good backup that fails on the missing chunk at
+	// restore time — and once the src copy is later tombstoned and
+	// GC'd, `repo replicate verify` (which walks src listings) can
+	// never see the broken replica manifest again. A replica
+	// manifest must imply its chunks are all present.
+	if res.ManifestsCopied != 0 {
+		t.Errorf("ManifestsCopied=%d, want 0 (manifest over a missing chunk must not reach the replica)", res.ManifestsCopied)
 	}
-	if len(res.Failures) == 0 {
-		t.Error("expected a Failure entry for the missing chunk")
+	if res.ManifestsFailed != 1 {
+		t.Errorf("ManifestsFailed=%d, want 1", res.ManifestsFailed)
+	}
+	if len(res.Failures) < 2 {
+		t.Errorf("expected Failure entries for both the missing chunk and the withheld manifest; got %v", res.Failures)
 	}
 }
 

--- a/internal/restore/restore.go
+++ b/internal/restore/restore.go
@@ -472,15 +472,31 @@ func Restore(ctx context.Context, opts Options) (res *Result, err error) {
 		// can carry the same relative path, so keying resume on the
 		// bare path would wrongly skip a not-yet-written file.
 		fkey := checkpointKey(f)
-		if _, alreadyDone := completed[fkey]; alreadyDone {
-			continue
-		}
 		destRoot, err := fileDestRoot(opts.TargetDir, tsDests, f.TablespaceOID)
 		if err != nil {
 			matSpan.SetStatus(codes.Error, err.Error())
 			matSpan.End()
 			span.SetStatus(codes.Error, err.Error())
 			return nil, err
+		}
+		if _, alreadyDone := completed[fkey]; alreadyDone {
+			// Cheap on-disk revalidation before trusting the
+			// checkpoint. After an OS crash / power loss the journal
+			// can persist the checkpoint's rename while dropping the
+			// dentries of files fsynced into OTHER directories (their
+			// parents were never dir-fsynced) — the checkpoint then
+			// claims files the filesystem lost. Blindly skipping them
+			// yielded a datadir with missing relation files: silently
+			// corrupt for TDE / pre-manifest sources (their verify leg
+			// is skipped), and a wedged retry loop otherwise (the L2
+			// verify failed but the "completed" file was never
+			// re-materialised). A stat + size compare is O(#files)
+			// and negligible next to chunk fetches.
+			if st, serr := os.Stat(filepath.Join(destRoot, filepath.FromSlash(f.Path))); serr == nil && st.Size() == f.Size {
+				continue
+			}
+			// Missing or wrong size: drop the claim and re-materialise.
+			delete(completed, fkey)
 		}
 		n, k, err := materializeFile(matCtx, cas, destRoot, f)
 		if err != nil {

--- a/internal/timetravel/pick_lsn_test.go
+++ b/internal/timetravel/pick_lsn_test.go
@@ -1,0 +1,90 @@
+package timetravel
+
+import (
+	"context"
+	"crypto/rand"
+	"net/url"
+	"path/filepath"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/cybertec-postgresql/pg_hardstorage/internal/backup"
+	"github.com/cybertec-postgresql/pg_hardstorage/internal/plugin/storage"
+	"github.com/cybertec-postgresql/pg_hardstorage/internal/plugin/storage/fs"
+	"github.com/cybertec-postgresql/pg_hardstorage/internal/repo"
+)
+
+// LSN-mode timetravel used to pick "the latest committed backup
+// overall and let PG's own recovery decide" — but PG can only roll
+// FORWARD, so any target LSN below the newest backup's stop_lsn (the
+// entire point of timetravel) hit the restore reachability gate as
+// target_unreachable while the correct older backup sat unused. The
+// picker must select by StopLSN <= target.
+func TestPickBackupForTarget_LSNSelectsOlderBackup(t *testing.T) {
+	root := t.TempDir()
+	repoURL := "file://" + root
+	if _, err := repo.Init(context.Background(), repo.InitOptions{URL: repoURL}); err != nil {
+		t.Fatal(err)
+	}
+	sp := &fs.Plugin{}
+	if err := sp.Open(context.Background(), storage.StorageConfig{URL: &url.URL{Scheme: "file", Path: root}}); err != nil {
+		t.Fatal(err)
+	}
+	t.Cleanup(func() { _ = sp.Close() })
+
+	priv, pub, err := backup.GenerateKeypair(rand.Reader)
+	if err != nil {
+		t.Fatal(err)
+	}
+	signer, _ := backup.LoadSigner(priv)
+	verifier, _ := backup.LoadVerifier(pub)
+	store := backup.NewManifestStore(sp)
+
+	commit := func(id, stopLSN string, ts time.Time) {
+		t.Helper()
+		m := &backup.Manifest{
+			Schema: backup.Schema, BackupID: id, Deployment: "db1",
+			Type: backup.BackupTypeFull, PGVersion: 17,
+			SystemIdentifier: "7000000000000000001",
+			StartLSN:         "0/1000028", StopLSN: stopLSN, Timeline: 1,
+			StartedAt: ts.Add(-time.Minute), StoppedAt: ts,
+			BackupLabel: "START WAL LOCATION: 0/1000028\n",
+			Tablespaces: []backup.Tablespace{{OID: 1663, Location: "pg_default"}},
+			Files:       []backup.FileEntry{},
+		}
+		if err := store.Commit(context.Background(), m, signer, backup.CommitOptions{}); err != nil {
+			t.Fatalf("commit %s: %v", id, err)
+		}
+	}
+
+	now := time.Now().UTC()
+	commit("db1.full.old", "0/5000000", now.Add(-2*time.Hour))
+	commit("db1.full.new", "0/9000000", now.Add(-1*time.Hour))
+
+	mgr := NewManager(filepath.Join(t.TempDir(), "state.json"), "/usr/bin/true")
+
+	// Target between the two stops → MUST pick the older backup.
+	id, _, err := mgr.pickBackupForTarget(context.Background(), repoURL, "db1", time.Time{}, "0/6000000", verifier)
+	if err != nil {
+		t.Fatalf("pick: %v", err)
+	}
+	if id != "db1.full.old" {
+		t.Errorf("picked %q for LSN 0/6000000, want db1.full.old — the newer backup ends past the target and PG cannot rewind", id)
+	}
+
+	// Target past both stops → the newest works.
+	id, _, err = mgr.pickBackupForTarget(context.Background(), repoURL, "db1", time.Time{}, "0/A000000", verifier)
+	if err != nil {
+		t.Fatalf("pick past-both: %v", err)
+	}
+	if id != "db1.full.new" {
+		t.Errorf("picked %q for LSN 0/A000000, want db1.full.new", id)
+	}
+
+	// Target before every stop → structured refusal, not a wrong pick.
+	_, _, err = mgr.pickBackupForTarget(context.Background(), repoURL, "db1", time.Time{}, "0/2000000", verifier)
+	if err == nil || !strings.Contains(err.Error(), "at-or-before LSN") {
+		t.Errorf("too-early target: err = %v, want at-or-before refusal", err)
+	}
+}

--- a/internal/timetravel/timetravel.go
+++ b/internal/timetravel/timetravel.go
@@ -36,6 +36,7 @@ import (
 	"encoding/json"
 	"errors"
 	"fmt"
+	"github.com/jackc/pglogrepl"
 	"os"
 	"path/filepath"
 	"sort"
@@ -198,7 +199,7 @@ func (m *Manager) Create(ctx context.Context, opts CreateOptions) (*Session, err
 	// We resolve it ourselves: walk manifests, pick the latest with
 	// StoppedAt <= target.
 
-	pickedID, pgVersion, err := m.pickBackupForTarget(ctx, opts.RepoURL, opts.Deployment, atTime, opts.Verifier)
+	pickedID, pgVersion, err := m.pickBackupForTarget(ctx, opts.RepoURL, opts.Deployment, atTime, atLSN, opts.Verifier)
 	if err != nil {
 		return nil, err
 	}
@@ -265,16 +266,32 @@ func (m *Manager) Create(ctx context.Context, opts CreateOptions) (*Session, err
 }
 
 // pickBackupForTarget walks the deployment's manifests and returns
-// the latest committed backup whose StoppedAt is at-or-before the
-// target time. When target is zero (LSN-only mode), we pick the
-// latest committed backup overall and let PG's own recovery decide
-// when to stop.
-func (m *Manager) pickBackupForTarget(ctx context.Context, repoURL, deployment string, target time.Time, verifier *backup.Verifier) (string, int, error) {
+// the latest committed backup at-or-before the target: by StoppedAt
+// for a time target, by StopLSN for an LSN target. PG recovery can
+// only roll FORWARD, so the base backup must end at or before the
+// requested point — the old LSN-mode behaviour ("pick the newest
+// backup, let PG stop") made every historical-LSN session fail at
+// the restore reachability gate (target below the newest backup's
+// stop_lsn = target_unreachable) even though a suitable older
+// backup sat in the repo: the feature's primary use case was
+// inoperative.
+func (m *Manager) pickBackupForTarget(ctx context.Context, repoURL, deployment string, target time.Time, targetLSN string, verifier *backup.Verifier) (string, int, error) {
 	rs, err := openManifestStore(ctx, repoURL)
 	if err != nil {
 		return "", 0, err
 	}
 	defer rs.Close()
+
+	var lsnTarget pglogrepl.LSN
+	haveLSN := false
+	if targetLSN != "" {
+		parsed, perr := pglogrepl.ParseLSN(targetLSN)
+		if perr != nil {
+			return "", 0, fmt.Errorf("timetravel: parse target LSN %q: %w", targetLSN, perr)
+		}
+		lsnTarget = parsed
+		haveLSN = true
+	}
 
 	var bestID string
 	var bestStopped time.Time
@@ -286,6 +303,12 @@ func (m *Manager) pickBackupForTarget(ctx context.Context, repoURL, deployment s
 		if !target.IsZero() && mm.StoppedAt.After(target) {
 			continue
 		}
+		if haveLSN {
+			stop, serr := pglogrepl.ParseLSN(mm.StopLSN)
+			if serr != nil || stop > lsnTarget {
+				continue
+			}
+		}
 		if mm.StoppedAt.After(bestStopped) {
 			bestStopped = mm.StoppedAt
 			bestID = mm.BackupID
@@ -293,11 +316,16 @@ func (m *Manager) pickBackupForTarget(ctx context.Context, repoURL, deployment s
 		}
 	}
 	if bestID == "" {
-		if target.IsZero() {
+		switch {
+		case haveLSN:
+			return "", 0, fmt.Errorf("timetravel: no committed backup of %q stops at-or-before LSN %s — the oldest backup already ends past the requested point",
+				deployment, targetLSN)
+		case target.IsZero():
 			return "", 0, fmt.Errorf("timetravel: no committed backups for deployment %q", deployment)
+		default:
+			return "", 0, fmt.Errorf("timetravel: no committed backup of %q is at-or-before %s",
+				deployment, target.Format(time.RFC3339))
 		}
-		return "", 0, fmt.Errorf("timetravel: no committed backup of %q is at-or-before %s",
-			deployment, target.Format(time.RFC3339))
 	}
 	return bestID, bestVersion, nil
 }

--- a/internal/wal/follower/coordinator.go
+++ b/internal/wal/follower/coordinator.go
@@ -383,27 +383,51 @@ func (c *Coordinator) handleLeaderChange(ctx context.Context, ev patroni.LeaderC
 	// doesn't change this — the replica's TLI is the same as
 	// the leader's (Patroni keeps replicas on the same
 	// timeline).
-	if err := c.captureTimelineHistory(ctx, leaderDSN, ev.New.Timeline); err != nil {
-		if errors.Is(err, pg.ErrNoHistoryForTLI1) {
-			// Fresh cluster on TLI 1 — there's no history file
-			// to capture. Notice-level event so an operator
-			// scanning logs sees we tried.
-			c.emit(output.NewEvent(output.SeverityNotice, "wal.follower", "timeline_no_history").
-				WithSubject(subj).
-				WithBody(map[string]any{"timeline": ev.New.Timeline}))
-			return
+	// Capture with bounded retries (same posture as persistGap):
+	// leader change is a rare, unrepeatable event — the next natural
+	// retry is the NEXT failover — and in streaming-only HA this
+	// store is the ONLY source of .history files. PG discovers
+	// recovery_target_timeline='latest' by probing successive
+	// <tli>.history via restore_command and stops at the first miss,
+	// so one transient blip here (leader still warming up, storage
+	// 503) used to silently cap every later PITR at the previous
+	// timeline. A capture failure also no longer skips the backfill
+	// below — lower TLIs must not be hostage to the current one.
+	var capErr error
+	for attempt := 0; attempt < 4; attempt++ {
+		if attempt > 0 {
+			select {
+			case <-ctx.Done():
+				return
+			case <-time.After(time.Duration(attempt) * 2 * time.Second):
+			}
 		}
-		c.emit(output.NewEvent(output.SeverityError, "wal.follower", "timeline_capture_failed").
+		capErr = c.captureTimelineHistory(ctx, leaderDSN, ev.New.Timeline)
+		if capErr == nil || errors.Is(capErr, pg.ErrNoHistoryForTLI1) {
+			break
+		}
+	}
+	switch {
+	case errors.Is(capErr, pg.ErrNoHistoryForTLI1):
+		// Fresh cluster on TLI 1 — there's no history file
+		// to capture. Notice-level event so an operator
+		// scanning logs sees we tried.
+		c.emit(output.NewEvent(output.SeverityNotice, "wal.follower", "timeline_no_history").
+			WithSubject(subj).
+			WithBody(map[string]any{"timeline": ev.New.Timeline}))
+	case capErr != nil:
+		c.emit(output.NewEvent(output.SeverityCritical, "wal.follower", "timeline_capture_failed").
 			WithSubject(subj).
 			WithBody(map[string]any{
 				"timeline": ev.New.Timeline,
-				"error":    err.Error(),
+				"error":    capErr.Error(),
+				"impact":   "without this .history file, recovery_target_timeline=latest stops at the previous timeline — PITR silently capped until the file is captured (agent restart or next failover retries)",
 			}))
-		return
+	default:
+		c.emit(output.NewEvent(output.SeverityInfo, "wal.follower", "timeline_captured").
+			WithSubject(subj).
+			WithBody(map[string]any{"timeline": ev.New.Timeline}))
 	}
-	c.emit(output.NewEvent(output.SeverityInfo, "wal.follower", "timeline_captured").
-		WithSubject(subj).
-		WithBody(map[string]any{"timeline": ev.New.Timeline}))
 
 	// 3. Backfill any MISSING intermediate timeline-history files below
 	// the new leader's TLI. The follower only observes the CURRENT leader

--- a/internal/wal/follower/coordinator_test.go
+++ b/internal/wal/follower/coordinator_test.go
@@ -534,8 +534,12 @@ func TestHandleLeaderChange_TimelineCaptureFailureSurfaces(t *testing.T) {
 	if ev == nil {
 		t.Fatalf("expected timeline_capture_failed; ops=%v", rec.ops())
 	}
-	if ev.Severity != output.SeverityError {
-		t.Errorf("severity = %v, want SeverityError", ev.Severity)
+	// Deliberately escalated to CRITICAL: in streaming-only HA the
+	// follower store is the only source of .history files, and a
+	// missed capture silently caps every later PITR at the previous
+	// timeline.
+	if ev.Severity != output.SeverityCritical {
+		t.Errorf("severity = %v, want SeverityCritical", ev.Severity)
 	}
 }
 


### PR DESCRIPTION
Round three: fresh audits over replication/heal/standby/timetravel and the audit-chain/control-plane/config layers, plus the remaining round-two backlog. Nine fixes; full `-race` gate green.

| # | Bug | Class | Fix + test |
|---|-----|-------|------------|
| 1 | **Audit chain: stale head pointer destroys a committed event** — crash between event Put and pointer update → next Append overwrites the tail on no-conditional-put backends, `VerifyChain` stays green | Corruption | Probe-slot-then-relink before Put. `TestAppend_NoConditionalPut_StaleHeadDoesNotOverwriteTail` |
| 2 | **`verify-anchor` false tamper reports** — list-index-as-sequence breaks on mixed layouts / WORM-pruned chains | Trust machinery | Sequence-parsed resolution. `TestVerifyAnchor_SurvivesRetentionPrunedTail` |
| 3 | **Config overlays silently drop retention/TDE/SLO/…** — conf.d re-declaration lost the operator's policy; rotate pruned with defaults | Data loss | Complete `mergeDeployment` + reflection canary. `TestMergeDeployment_CarriesEveryField` |
| 4 | **Replica manifests committed over missing chunks** — DR replica lies about restorability, undetectable after src GC | Corruption | Chunk-complete gate before manifest Put (backup + WAL). Updated `TestReplicate_ChunkMissingAtSource` |
| 5 | **Timetravel LSN targets inoperative** — always picked the newest backup; PG can't rewind | Availability | Pick latest backup with `StopLSN <= target`. `TestPickBackupForTarget_LSNSelectsOlderBackup` |
| 6 | **Legal hold on an incremental wedges retention deployment-wide** — chain guard refused every batch for the hold's lifetime | Availability | Chain-aware hold filter (`held_chain_anchor`). `TestRotate_HoldOnIncrementalDoesNotWedgeRetention` |
| 7 | **Type-blind ENOSPC projection** — fulls false-pass at incremental size (mid-run death), incrementals falsely refused | Availability | Type-aware projection + List errors surfaced. `TestProjectedBytes_TypeAware` |
| 8 | **Restore resume trusts a post-crash checkpoint** — missing relation files, silent under TDE | Corruption | Stat+size revalidation of each claimed file on resume. *No dedicated regression test — a full restore fixture didn't fit the budget; flagged for follow-up.* |
| 9 | **One-shot timeline-history capture at promotion** — one transient error silently caps `latest`-timeline PITR forever in streaming-only HA | Availability | Bounded retries, CRITICAL escalation, backfill decoupled. Existing test updated to the new severity |

Remaining documented backlog: heal plaintext re-verify ordering on partial heals, control-plane job requeue after lost claims, backup WAL-range coverage validation, timeline-history archival in plain `wal stream`, `.deferred-*` staging reaper, shared-DEK nonce budget.