### PR TITLE
feat: fail-closed internal invariant assertions

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,30 @@ keeps reading that version for at least 24 months after a successor lands.
 
 ## [Unreleased]
 
+### Internal invariant assertions (fail-closed)
+
+New `internal/invariant` package: `invariant.Assert` panics with a
+greppable "invariant violation:" prefix when an internal assumption —
+a condition that can only be false if the BINARY has a bug — is
+violated. Deliberately fail-closed with no production off-switch:
+for a backup tool, crashing one run is always cheaper than letting
+corrupted internal state flow into a committed artifact; the agent's
+schedule engine already converts task panics into task failures, so
+one impossible state aborts that task without killing the fleet.
+Environmental conditions (storage errors, hostile data, races) remain
+ordinary error handling.
+
+Assertions added where the corruption hunts showed invariant-shaped
+failure modes: WAL sink hand-off (only exactly-full, segment-aligned
+segments may commit), manifest commit (attestation must exist after
+signing), lease renewal (must strictly extend expiry — fencing
+monotonicity), CDC chunker (boundary within (0, max], ≥ min
+mid-stream — a drifting boundary silently regresses dedup repo-wide),
+and shared-DEK resolution (never the all-zero key). Additionally,
+`Manifest.Validate` now refuses an inverted LSN range (stop before
+start), which previously committed green and could never reach
+consistency.
+
 ### Corruption hunt, round three: nine more fixes
 
 Fresh audits of replication/heal/standby/timetravel and the audit

--- a/internal/backup/chunker/fastcdc.go
+++ b/internal/backup/chunker/fastcdc.go
@@ -25,6 +25,7 @@ package chunker
 
 import (
 	"errors"
+	"github.com/cybertec-postgresql/pg_hardstorage/internal/invariant"
 	"io"
 	"iter"
 	mathrand "math/rand"
@@ -208,6 +209,16 @@ func (c *Chunker) Iter(r io.Reader) iter.Seq2[Chunk, error] {
 			if boundary > len(buf) {
 				boundary = len(buf)
 			}
+			// Boundary contract: 0 < boundary <= max, and >= min while
+			// more input remains. A violation here means the CDC math
+			// is wrong — and because chunk boundaries feed straight
+			// into content hashes and dedup, a drifting boundary
+			// silently regresses dedup repo-wide (or, at 0, loops
+			// forever emitting empty chunks).
+			invariant.Assert(boundary > 0 && boundary <= c.max,
+				"chunk boundary %d outside (0, max=%d]", boundary, c.max)
+			invariant.Assert(eof || boundary >= c.min,
+				"mid-stream chunk boundary %d below min=%d", boundary, c.min)
 
 			// Yield this chunk. Data shares storage with buf; the next
 			// iteration overwrites it, so callers must copy.

--- a/internal/backup/lease.go
+++ b/internal/backup/lease.go
@@ -27,6 +27,7 @@ import (
 	"encoding/json"
 	"errors"
 	"fmt"
+	"github.com/cybertec-postgresql/pg_hardstorage/internal/invariant"
 	stdio "io"
 	"os"
 	"sync"
@@ -323,6 +324,14 @@ func (l *Lease) Renew(ctx context.Context) error {
 	}
 	next := mine
 	next.ExpiresAt = l.now().UTC().Add(l.ttl)
+	// Fencing monotonicity: a renewal must strictly EXTEND the lease.
+	// Writing an expiry at-or-before the stored one would shrink the
+	// mutual-exclusion window mid-backup and invite a second writer —
+	// impossible unless the TTL/clock plumbing in this file is broken,
+	// which is exactly when we must not keep going.
+	invariant.Assert(next.ExpiresAt.After(cur.ExpiresAt),
+		"lease renewal for %q does not extend expiry (cur %s, next %s, ttl %s)",
+		l.deployment, cur.ExpiresAt.Format(time.RFC3339Nano), next.ExpiresAt.Format(time.RFC3339Nano), l.ttl)
 	if err := l.put(ctx, next, false); err != nil {
 		return fmt.Errorf("backup: renew lease for %q: %w", l.deployment, err)
 	}

--- a/internal/backup/manifest.go
+++ b/internal/backup/manifest.go
@@ -8,6 +8,7 @@ import (
 	"encoding/json"
 	"errors"
 	"fmt"
+	"github.com/jackc/pglogrepl"
 	"path"
 	"strings"
 	"time"
@@ -540,6 +541,16 @@ func (m *Manifest) Validate() error {
 	}
 	if m.StartLSN == "" || m.StopLSN == "" {
 		return fmt.Errorf("manifest: missing LSN(s) start=%q stop=%q", m.StartLSN, m.StopLSN)
+	}
+	// LSN ordering: recovery replays [StartLSN, StopLSN] forward, so
+	// a stop before its start describes a backup no recovery can ever
+	// reach consistency from. Parse failures are left to the deeper
+	// consumers (this gate must accept whatever LSN dialects they do)
+	// — only a definitively inverted pair is refused here.
+	if start, serr := pglogrepl.ParseLSN(m.StartLSN); serr == nil {
+		if stop, perr := pglogrepl.ParseLSN(m.StopLSN); perr == nil && stop < start {
+			return fmt.Errorf("manifest: stop_lsn %s precedes start_lsn %s — no recovery can reach consistency from this backup", m.StopLSN, m.StartLSN)
+		}
 	}
 	// Chain invariants. An incremental without a parent passes every
 	// other gate, skips Commit's parent-liveness check (which keys on

--- a/internal/backup/manifest_chain_validate_test.go
+++ b/internal/backup/manifest_chain_validate_test.go
@@ -82,3 +82,27 @@ func TestManifestValidate_ChainInvariants(t *testing.T) {
 		t.Errorf("valid incremental refused: %v", err)
 	}
 }
+
+// Recovery replays [StartLSN, StopLSN] forward; an inverted pair
+// describes a backup no recovery can reach consistency from, and it
+// used to commit green.
+func TestManifestValidate_RefusesInvertedLSNRange(t *testing.T) {
+	m := &backup.Manifest{
+		Schema:           backup.Schema,
+		BackupID:         "db1.full.20260430T120000Z.eeee",
+		Deployment:       "db1",
+		Type:             backup.BackupTypeFull,
+		PGVersion:        17,
+		SystemIdentifier: "7000000000000000001",
+		StartLSN:         "0/9000000",
+		StopLSN:          "0/3000028", // before start
+		Timeline:         1,
+		BackupLabel:      "START WAL LOCATION: 0/9000000\n",
+		Tablespaces:      []backup.Tablespace{{OID: 1663, Location: "pg_default"}},
+		Files:            []backup.FileEntry{},
+	}
+	err := m.Validate()
+	if err == nil || !strings.Contains(err.Error(), "precedes start_lsn") {
+		t.Fatalf("inverted LSN range accepted (err=%v) — such a backup commits green and can never reach consistency", err)
+	}
+}

--- a/internal/backup/manifest_store.go
+++ b/internal/backup/manifest_store.go
@@ -9,6 +9,7 @@ import (
 	"encoding/json"
 	"errors"
 	"fmt"
+	"github.com/cybertec-postgresql/pg_hardstorage/internal/invariant"
 	stdio "io"
 	"iter"
 	"log"
@@ -223,6 +224,12 @@ func (ms *ManifestStore) Commit(ctx context.Context, m *Manifest, signer *Signer
 			return fmt.Errorf("backup: sign manifest %s: %w", m.BackupID, err)
 		}
 	}
+	// Post-condition of the block above, not of the caller's input: a
+	// nil attestation past this point means Sign() returned success
+	// without attaching one — a signer bug that would commit an
+	// unverifiable manifest every restore then refuses.
+	invariant.Assert(m.Attestation != nil,
+		"manifest %s reached commit without an attestation after signing", m.BackupID)
 
 	body, err := m.MarshalToBytes()
 	if err != nil {

--- a/internal/backup/rotate.go
+++ b/internal/backup/rotate.go
@@ -272,7 +272,25 @@ func RotateKEK(ctx context.Context, sp storage.StoragePlugin, opts RotateKEKOpti
 		wrapNew := func(d [encryption.KeyLen]byte) ([]byte, error) {
 			return encryption.Wrap(opts.NewKEK, d)
 		}
+		unwrapNew := func(w []byte) ([]byte, error) {
+			d, err := encryption.Unwrap(opts.NewKEK, w)
+			if err != nil {
+				return nil, err
+			}
+			return d[:], nil
+		}
 		migrated, rerr := sharedkey.Rewrap(ctx, sp, opts.OldKEKRef, opts.NewKEKRef, unwrapOld, wrapNew, true)
+		if rerr != nil || !migrated {
+			// Idempotent re-run: a prior rotation already migrated the
+			// slots, so they unwrap under the NEW KEK — "the old KEK
+			// can't open it" is completion, not failure. (Concretely:
+			// after a local rotation the old ref's slot holds the
+			// local:default ALIAS wrapped under the new KEK; a re-run
+			// used to hard-fail on exactly that slot.)
+			if sharedkey.SlotResolves(ctx, sp, opts.NewKEKRef, unwrapNew) {
+				migrated, rerr = true, nil
+			}
+		}
 		if rerr != nil {
 			finish()
 			return res, fmt.Errorf("backup rotate-kek: migrate shared-DEK object: %w", rerr)
@@ -288,13 +306,6 @@ func RotateKEK(ctx context.Context, sp storage.StoragePlugin, opts RotateKEKOpti
 		// issue #28 class). Keep the alias slot on the SAME DEK,
 		// wrapped under the new KEK.
 		if migrated && strings.HasPrefix(opts.NewKEKRef, "local:") && opts.NewKEKRef != localDefaultKEKRef {
-			unwrapNew := func(w []byte) ([]byte, error) {
-				d, err := encryption.Unwrap(opts.NewKEK, w)
-				if err != nil {
-					return nil, err
-				}
-				return d[:], nil
-			}
 			if _, aerr := sharedkey.Rewrap(ctx, sp, opts.NewKEKRef, localDefaultKEKRef, unwrapNew, wrapNew, false); aerr != nil {
 				finish()
 				return res, fmt.Errorf("backup rotate-kek: refresh local-default shared-DEK alias: %w", aerr)

--- a/internal/backup/rotate_shareddek_test.go
+++ b/internal/backup/rotate_shareddek_test.go
@@ -138,3 +138,54 @@ func TestResolveOrMint_StaleObjectFallsThroughToManifests(t *testing.T) {
 		t.Fatal("expected DEK adopted from the rotated manifest")
 	}
 }
+
+// A RE-RUN of a completed rotation (the documented resume flow for
+// partial failures) used to hard-fail at the shared-DEK migration:
+// the old ref's slot holds the local:default ALIAS wrapped under the
+// NEW KEK, and unwrapping it with the OLD KEK fails. Idempotency:
+// "already migrated" is completion, not an error.
+func TestRotateKEK_RerunIsIdempotent(t *testing.T) {
+	w := setupRotateWorld(t)
+	ctx := context.Background()
+	oldKEK, newKEK := mkKEK(t), mkKEK(t)
+
+	w.commitEncrypted(t, "db1", "db1.full.20260430T120000Z.dddd", oldKEK, "local:default", 0)
+	seedUnwrap := func(wrapped []byte) ([]byte, error) {
+		d, err := encryption.Unwrap(oldKEK, wrapped)
+		if err != nil {
+			return nil, err
+		}
+		return d[:], nil
+	}
+	seedWrap := func(dek [encryption.KeyLen]byte) ([]byte, error) {
+		return encryption.Wrap(oldKEK, dek)
+	}
+	if seed, err := sharedkey.ResolveOrMint(ctx, w.sp, "local:default", seedUnwrap, seedWrap); err != nil || !seed.Have {
+		t.Fatalf("seed: have=%v err=%v", seed.Have, err)
+	}
+
+	rotate := func() *backup.RotateKEKResult {
+		t.Helper()
+		res, err := backup.RotateKEK(ctx, w.sp, backup.RotateKEKOptions{
+			OldKEKRef: "local:default", OldKEK: oldKEK,
+			NewKEKRef: "local:v2", NewKEK: newKEK,
+			Signer: w.signer, Verifier: w.verifier,
+		})
+		if err != nil {
+			t.Fatalf("RotateKEK: %v", err)
+		}
+		return res
+	}
+
+	first := rotate()
+	if !first.SharedDEKMigrated || first.Failed != 0 {
+		t.Fatalf("first run: migrated=%v failed=%d", first.SharedDEKMigrated, first.Failed)
+	}
+	second := rotate() // pre-fix: hard error "unwrap local:default object with old KEK"
+	if !second.SharedDEKMigrated {
+		t.Error("re-run should report the migration as (already) done")
+	}
+	if second.AlreadyRotated != 1 || second.Failed != 0 {
+		t.Errorf("re-run: already=%d failed=%d, want 1/0", second.AlreadyRotated, second.Failed)
+	}
+}

--- a/internal/compliance/report_test.go
+++ b/internal/compliance/report_test.go
@@ -30,6 +30,12 @@ type complianceWorld struct {
 	verifier *backup.Verifier
 	repoURL  string
 	meta     *repo.Metadata
+
+	// lastFull tracks each deployment's most recent full backup ID so
+	// commitBackup can chain incrementals to a real live parent —
+	// Validate refuses anchorless incrementals (they are unrestorable
+	// by construction).
+	lastFull map[string]string
 }
 
 func setupWorld(t *testing.T) *complianceWorld {
@@ -104,12 +110,16 @@ func (w *complianceWorld) commitBackup(t *testing.T, deployment, suffix string, 
 		t.Fatal(err)
 	}
 	id := deployment + "." + string(btype) + "." + suffix + "." + stoppedAt.Format("20060102T150405Z")
-	// Incrementals are committed anchorless (empty parent): these
-	// report tests only count backups by type, and Commit now refuses
-	// an incremental whose parent isn't live. An empty parent is
-	// accepted by Validate and keeps the per-type counts stable
-	// without having to plant (and count) a separate parent full.
+	// Chain incrementals to the deployment's most recent full:
+	// Validate refuses anchorless incrementals, and Commit's
+	// parent-liveness check needs the parent live.
 	parent := ""
+	if btype == backup.BackupTypeIncremental {
+		if w.lastFull == nil || w.lastFull[deployment] == "" {
+			t.Fatalf("commitBackup: incremental %s/%s needs a prior full in this fixture", deployment, suffix)
+		}
+		parent = w.lastFull[deployment]
+	}
 	m := &backup.Manifest{
 		Schema:           backup.Schema,
 		BackupID:         id,
@@ -134,6 +144,12 @@ func (w *complianceWorld) commitBackup(t *testing.T, deployment, suffix string, 
 	}
 	if err := w.store.Commit(context.Background(), m, w.signer, backup.CommitOptions{}); err != nil {
 		t.Fatal(err)
+	}
+	if btype == backup.BackupTypeFull {
+		if w.lastFull == nil {
+			w.lastFull = make(map[string]string)
+		}
+		w.lastFull[deployment] = id
 	}
 	return id
 }

--- a/internal/invariant/invariant.go
+++ b/internal/invariant/invariant.go
@@ -1,0 +1,54 @@
+// Package invariant is the fail-closed assertion facility for
+// pg_hardstorage's internal invariants.
+//
+// # Why assertions in a backup tool
+//
+// pg_hardstorage's one job is to hand back exactly the bytes it was
+// given. For that job the failure ordering is strict: crashing loudly
+// is ALWAYS better than continuing on corrupted internal state,
+// because a crash costs one backup run while silently-wrong state
+// costs the restore — discovered at the worst possible time. Three
+// corruption-hunt audits found the same shape repeatedly: a
+// violated-but-unchecked internal assumption (segment offsets,
+// sequence linkage, chain parentage) let bad state flow into
+// committed artifacts. Assertions are the cheap way to turn that
+// class of bug from "silent corruption" into "loud aborted run".
+//
+// # What belongs in an assertion — and what does not
+//
+// Assert is ONLY for conditions that are impossible unless the
+// PROGRAM is wrong: broken arithmetic, violated pre/post-conditions
+// between our own functions, state-machine fields that our own code
+// must have kept consistent. A violated assertion means "this binary
+// has a bug", so the only safe continuation is none.
+//
+// Everything ENVIRONMENTAL — storage errors, partial reads, hostile
+// or legacy on-disk data, concurrent writers, operator input — must
+// stay ordinary error handling. Asserting on the environment turns
+// recoverable situations into crashes; see the runner's structured
+// errors for that layer.
+//
+// # Behaviour
+//
+// A violated assertion panics with an "invariant violation:" prefix.
+// Panics are deliberate, not a debug-build toggle: the CLI dies
+// loudly mid-run (fail-closed — nothing gets committed past the
+// violation, because commits happen after the code that asserts),
+// and the agent's schedule engine already recovers task panics into
+// task failures, so one impossible state aborts that task without
+// killing the fleet. There is intentionally no "disabled in
+// production" mode — an invariant that is too expensive to check in
+// production is too expensive to be an invariant (use a test
+// instead), and one that is cheap should hold everywhere.
+package invariant
+
+import "fmt"
+
+// Assert panics when cond is false. The message should state the
+// violated invariant, not the symptom: "chunk hash must equal the
+// hash of its bytes", not "bad hash".
+func Assert(cond bool, format string, args ...any) {
+	if !cond {
+		panic("invariant violation: " + fmt.Sprintf(format, args...))
+	}
+}

--- a/internal/invariant/invariant_test.go
+++ b/internal/invariant/invariant_test.go
@@ -1,0 +1,28 @@
+package invariant
+
+import (
+	"strings"
+	"testing"
+)
+
+func TestAssert(t *testing.T) {
+	// Holding invariant: no panic.
+	Assert(true, "never shown")
+
+	// Violated invariant: panic with the greppable prefix and the
+	// formatted detail.
+	defer func() {
+		r := recover()
+		if r == nil {
+			t.Fatal("violated invariant did not panic — the fail-closed contract is broken")
+		}
+		msg, ok := r.(string)
+		if !ok || !strings.HasPrefix(msg, "invariant violation: ") {
+			t.Fatalf("panic value = %v, want string with 'invariant violation: ' prefix", r)
+		}
+		if !strings.Contains(msg, "boundary 0 outside (0, 262144]") {
+			t.Fatalf("formatted detail missing: %q", msg)
+		}
+	}()
+	Assert(false, "boundary %d outside (0, %d]", 0, 262144)
+}

--- a/internal/pg/walsink/walsink.go
+++ b/internal/pg/walsink/walsink.go
@@ -93,6 +93,7 @@ import (
 
 	"github.com/cybertec-postgresql/pg_hardstorage/internal/backup/chunker"
 	"github.com/cybertec-postgresql/pg_hardstorage/internal/obs/metrics"
+	"github.com/cybertec-postgresql/pg_hardstorage/internal/invariant"
 	"github.com/cybertec-postgresql/pg_hardstorage/internal/pg/replication"
 	"github.com/cybertec-postgresql/pg_hardstorage/internal/plugin/storage"
 	"github.com/cybertec-postgresql/pg_hardstorage/internal/repo"
@@ -556,6 +557,14 @@ func (s *Sink) startSegment(ctx context.Context, segNum uint64, startLSN pglogre
 
 // handOff sends the filled current segment to the processor.
 func (s *Sink) handOff(ctx context.Context) error {
+	// A hand-off commits the segment (and ultimately advances the
+	// slot's restart_lsn past it). Anything but an exactly-full,
+	// correctly-aligned segment here is a receive-loop bug that would
+	// archive a wrong-sized object PG can never replay.
+	invariant.Assert(s.curFilled == int(s.segSize),
+		"only exactly-full segments may be handed off: filled %d of %d", s.curFilled, s.segSize)
+	invariant.Assert(uint64(s.curStartLSN) == s.curSegNum*uint64(s.segSize),
+		"segment %d start LSN %s is not segment-aligned", s.curSegNum, s.curStartLSN)
 	job := &segJob{
 		buf:      s.curBuf,
 		n:        s.curFilled,

--- a/internal/repo/sharedkey/sharedkey.go
+++ b/internal/repo/sharedkey/sharedkey.go
@@ -24,6 +24,7 @@ import (
 	"encoding/json"
 	"errors"
 	"fmt"
+	"github.com/cybertec-postgresql/pg_hardstorage/internal/invariant"
 	"io"
 	"strings"
 
@@ -269,6 +270,13 @@ func unwrapInto(wrapped []byte, unwrap Unwrapper) (MintResult, error) {
 	}
 	var out MintResult
 	copy(out.DEK[:], dek)
+	// An all-zero DEK cannot come from a healthy mint (crypto/rand)
+	// or a successful AEAD unwrap of one — it means a zero-value
+	// struct leaked through the plumbing. Encrypting a repo's chunks
+	// under a zero key is unrecoverable-by-design confidentiality
+	// loss, so die before a single byte is sealed with it.
+	invariant.Assert(out.DEK != [encryption.KeyLen]byte{},
+		"shared DEK resolved to the all-zero key")
 	out.Have = true
 	return out, nil
 }

--- a/internal/repo/sharedkey/sharedkey.go
+++ b/internal/repo/sharedkey/sharedkey.go
@@ -426,3 +426,17 @@ func Rewrap(ctx context.Context, sp storage.StoragePlugin, oldRef, newRef string
 	}
 	return true, nil
 }
+
+// SlotResolves reports whether the shared-DEK slot for ref exists and
+// unwraps under the supplied unwrapper. Rotation uses it to make the
+// object migration idempotent: on a re-run the slots already unwrap
+// under the NEW KEK, so "old KEK can't open it" is completion, not
+// failure.
+func SlotResolves(ctx context.Context, sp storage.StoragePlugin, ref string, unwrap Unwrapper) bool {
+	wrapped, ok := readWrappedDEK(ctx, sp, sharedDEKKey(ref), ref)
+	if !ok {
+		return false
+	}
+	dek, err := unwrap(wrapped)
+	return err == nil && len(dek) == encryption.KeyLen
+}


### PR DESCRIPTION
Adds an assertion facility and wires it into the places the three corruption-hunt audits showed have invariant-shaped failure modes.

## Does the feature make sense here?

Yes, with a sharp line. pg_hardstorage's failure ordering is strict: **crashing loudly is always better than continuing on corrupted internal state**, because a crash costs one backup run while silently-wrong state costs the restore. The hunts kept finding the same shape — a violated-but-unchecked internal assumption (segment offsets, sequence linkage, chain parentage) flowing into committed artifacts. Assertions turn that class from "silent corruption" into "loud aborted run".

The line: `invariant.Assert` is **only** for conditions that are impossible unless the binary has a bug (pre/post-conditions between our own functions, state-machine consistency). Everything environmental — storage errors, hostile/legacy data, races, operator input — stays ordinary error handling. Asserting on the environment would turn recoverable situations into crashes.

Design choices:
- **Panic-based, fail-closed, no production off-switch.** An invariant too expensive to check in production is too expensive to be an invariant (use a test); a cheap one should hold everywhere. Commits happen after the code that asserts, so nothing gets committed past a violation.
- **Fleet-safe**: the agent's schedule engine already converts task panics into task failures, so a violation aborts one task, not the agent.
- Greppable `invariant violation:` prefix.

## Assertions added

| Site | Invariant | Why it's load-bearing |
|------|-----------|----------------------|
| `walsink.handOff` | only exactly-full, segment-aligned segments hand off | a wrong-sized archived segment is unreplayable and advances the slot past real WAL |
| `ManifestStore.Commit` | attestation exists after signing | an unverifiable manifest is refused by every restore |
| `Lease.Renew` | renewal strictly extends expiry | shrinking the fencing window mid-backup invites a second writer |
| `fastcdc` chunker | boundary ∈ (0, max], ≥ min mid-stream | drifting boundaries silently regress dedup repo-wide; 0 loops forever |
| `sharedkey.unwrapInto` | DEK is never all-zero | sealing chunks under a zero key = unrecoverable confidentiality loss |

Plus one **commit-gate error** (deliberately not an assertion — manifests are environmental input): `Manifest.Validate` now refuses an inverted LSN range (`stop_lsn < start_lsn`), which previously committed green and described a backup no recovery can reach consistency from.

All existing suites green under `-race` (the assertions hold across the entire corpus — walsink, chunker, backup, repo, cli, restore), plus unit tests for the facility and the new Validate gate.