### PR TITLE
config: add allow_unenforceable_lease to DeploymentConfig

### DIFF
--- a/internal/agent/executor.go
+++ b/internal/agent/executor.go
@@ -166,6 +166,7 @@ func (b *BackupExecutor) runBackup(ctx context.Context, job *ControlPlaneJob, pr
 		InactivityTimeout: inactivity,
 		OnEvent:           emit,
 		Encryption:        enc,
+		SkipLease:         dep.AllowUnenforceableLease,
 		// Actor in the audit chain: the dispatch path uses the
 		// agent-id-on-job, distinguishing scheduler-driven backups
 		// from operator-initiated ones.

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -314,6 +314,17 @@ type DeploymentConfig struct {
 	// Default (zero value, Enabled=false) means "no TDE" — the
 	// historical behaviour with strict on-disk header parsing.
 	TDE TDEConfig `yaml:"tde,omitempty" json:"tde,omitempty"`
+
+	// AllowUnenforceableLease proceeds even when the storage backend cannot
+	// perform atomic conditional writes (ConditionalPut=false), such as Ceph
+	// S3 or some MinIO deployments.  The scheduled-backup lease is then
+	// best-effort: a second concurrent runner could hold the same lease.
+	//
+	// Safe when exactly one agent replica exists — the StatefulSet chart
+	// enforces replicas=1 and documents this constraint.  Set to true only
+	// when you are certain no other agent backs up this deployment
+	// concurrently.
+	AllowUnenforceableLease bool `yaml:"allow_unenforceable_lease,omitempty" json:"allow_unenforceable_lease,omitempty"`
 }
 
 // TDEConfig declares Transparent Data Encryption posture for a
@@ -1008,6 +1019,9 @@ func mergeDeployment(existing, overlay DeploymentConfig) DeploymentConfig {
 	}
 	if overlay.Classification != "" {
 		existing.Classification = overlay.Classification
+	}
+	if overlay.AllowUnenforceableLease {
+		existing.AllowUnenforceableLease = true
 	}
 	return existing
 }

--- a/internal/config/config_test.go
+++ b/internal/config/config_test.go
@@ -600,3 +600,45 @@ func TestLoad_SampleYAMLParses(t *testing.T) {
 		t.Error("encrypted-pgee.tde.enabled must be true in the sample (this is the TDE-source example)")
 	}
 }
+
+// TestLoad_AllowUnenforceableLeaseRoundTrip confirms that
+// allow_unenforceable_lease parses into DeploymentConfig and that the
+// zero value (omitted) defaults to false.  Catches a YAML-tag
+// regression that would silently ignore the operator's declaration
+// and leave the scheduled agent unable to acquire a lease on Ceph S3
+// or other backends without atomic conditional writes.
+func TestLoad_AllowUnenforceableLeaseRoundTrip(t *testing.T) {
+	dir := t.TempDir()
+	writeFile(t, filepath.Join(dir, "pg_hardstorage.yaml"), `
+schema: pg_hardstorage.config.v1
+deployments:
+  ceph-s3:
+    pg_connection: postgres://backup@db/postgres
+    repo: s3://bucket/prefix?endpoint=https://ceph.example.com
+    allow_unenforceable_lease: true
+  strict:
+    pg_connection: postgres://backup@db/postgres
+    repo: s3://bucket/strict
+    # no allow_unenforceable_lease: defaults to false
+`)
+	p := pathsForTempDir(t, dir)
+	res, err := config.Load(p)
+	if err != nil {
+		t.Fatalf("Load: %v", err)
+	}
+	ceph, ok := res.Config.Deployments["ceph-s3"]
+	if !ok {
+		t.Fatal("ceph-s3 missing from deployments")
+	}
+	if !ceph.AllowUnenforceableLease {
+		t.Errorf("ceph-s3.allow_unenforceable_lease = false, want true")
+	}
+
+	strict, ok := res.Config.Deployments["strict"]
+	if !ok {
+		t.Fatal("strict missing from deployments")
+	}
+	if strict.AllowUnenforceableLease {
+		t.Errorf("strict.allow_unenforceable_lease = true; expected default false")
+	}
+}

--- a/internal/config/marshal_roundtrip_test.go
+++ b/internal/config/marshal_roundtrip_test.go
@@ -62,6 +62,7 @@ func fullDeployment(useSlots bool) config.DeploymentConfig {
 			Slots:        slots,
 			Interval:     "10s",
 		},
+		AllowUnenforceableLease: true,
 	}
 }
 

--- a/internal/config/merge_completeness_test.go
+++ b/internal/config/merge_completeness_test.go
@@ -44,6 +44,7 @@ func TestMergeDeployment_CarriesEveryField(t *testing.T) {
 			PasswordFile: "/pw", Slot: "s", Slots: []PatroniSlot{{Name: "a", Role: "leader"}},
 			Interval: "10s",
 		},
+		AllowUnenforceableLease: true,
 	}
 
 	got := mergeDeployment(base, overlay)


### PR DESCRIPTION


## Summary

Problem: Ceph S3 and some MinIO deployments do not support atomic conditional writes (ConditionalPut=false). The agent's scheduled backup tasks hard-wire SkipLease=false, causing them to always fail on these backends with backup.lease_failed.

The backup CLI has --allow-concurrent for ad-hoc runs, but the agent scheduler has no equivalent config option, making scheduled backups impossible on Ceph-backed S3 with replicas=1.
Safe when: StatefulSet replicas=1 (which the chart enforces and documents). The operator takes explicit responsibility by setting the flag, matching the existing --allow-concurrent semantics.

## Type
- [X] New feature

